### PR TITLE
#7: Support Kotlin data classes in StdReflector

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tech.ydb.yoj</groupId>
     <artifactId>yoj-bom</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>YOJ - Bill of Materials</name>

--- a/databind/pom.xml
+++ b/databind/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -34,5 +34,59 @@
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Optional (Kotlin support) -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compileTests</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <source>src/test/kotlin</source>
+                                <source>target/generated-sources/annotations</source>
+                            </sourceDirs>
+                            <jvmTarget>17</jvmTarget>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
 </project>

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassComponent.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassComponent.java
@@ -1,0 +1,84 @@
+package tech.ydb.yoj.databind.schema.reflect;
+
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KCallable;
+import kotlin.reflect.jvm.ReflectJvmMapping;
+import tech.ydb.yoj.databind.FieldValueType;
+import tech.ydb.yoj.databind.schema.Column;
+import tech.ydb.yoj.databind.schema.FieldValueException;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Type;
+
+/**
+ * Represents a Kotlin data class component for the purposes of YOJ data-binding.
+ */
+public final class KotlinDataClassComponent implements ReflectField {
+    private final KCallable<?> callable;
+
+    private final String name;
+    private final Type genericType;
+    private final Class<?> type;
+    private final FieldValueType valueType;
+    private final Column column;
+    
+    private final ReflectType<?> reflectType;
+
+    public KotlinDataClassComponent(Reflector reflector, String name, KCallable<?> callable) {
+        this.callable = callable;
+
+        this.name = name;
+
+        var kReturnType = callable.getReturnType();
+        this.genericType = ReflectJvmMapping.getJavaType(kReturnType);
+        this.type = JvmClassMappingKt.getJavaClass(kReturnType);
+        this.column = type.getAnnotation(Column.class);
+        this.valueType = FieldValueType.forJavaType(genericType, column);
+        this.reflectType = reflector.reflectFieldType(genericType, valueType);
+    }
+
+    @Nullable
+    @Override
+    public Object getValue(Object containingObject) {
+        try {
+            return callable.call(containingObject);
+        } catch (Exception e) {
+            throw new FieldValueException(e, getName(), containingObject);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Type getGenericType() {
+        return genericType;
+    }
+
+    @Override
+    public Class<?> getType() {
+        return type;
+    }
+
+    @Override
+    public FieldValueType getValueType() {
+        return valueType;
+    }
+
+    @Override
+    public Column getColumn() {
+        return column;
+    }
+
+    @Override
+    public ReflectType<?> getReflectType() {
+        return reflectType;
+    }
+
+    @Override
+    public String toString() {
+        return "KotlinDataClassComponent[val " + name + ": " + genericType.getTypeName() + "]";
+    }
+}

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassType.java
@@ -1,0 +1,95 @@
+package tech.ydb.yoj.databind.schema.reflect;
+
+import com.google.common.base.Preconditions;
+import kotlin.jvm.JvmClassMappingKt;
+import kotlin.reflect.KCallable;
+import kotlin.reflect.KMutableProperty;
+import kotlin.reflect.KParameter;
+import kotlin.reflect.full.KClasses;
+import kotlin.reflect.jvm.ReflectJvmMapping;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Represents a Kotlin data class for the purposes of YOJ data-binding.
+ */
+public final class KotlinDataClassType<T> implements ReflectType<T> {
+    private final Class<T> type;
+    private final Constructor<T> constructor;
+    private final List<ReflectField> fields;
+
+    public KotlinDataClassType(Reflector reflector, Class<T> type) {
+        this.type = type;
+
+        var kClass = JvmClassMappingKt.getKotlinClass(type);
+        var kClassName = kClass.getQualifiedName();
+        Preconditions.checkArgument(kClass.isData(),
+                "'%s' is not a data class",
+                kClassName);
+
+        var primaryKtConstructor = KClasses.getPrimaryConstructor(kClass);
+        Preconditions.checkArgument(primaryKtConstructor != null,
+                "'%s' has no primary constructor",
+                kClassName);
+
+        var primaryJavaConstructor = ReflectJvmMapping.getJavaConstructor(primaryKtConstructor);
+        Preconditions.checkArgument(primaryJavaConstructor != null,
+                "Could not get Java Constructor<%s> from KFunction: %s",
+                kClassName, primaryKtConstructor);
+        this.constructor = primaryJavaConstructor;
+        this.constructor.setAccessible(true);
+
+        var functions = KClasses.getDeclaredMemberFunctions(kClass).stream()
+                .filter(c -> KotlinDataClassTypeFactory.isComponentMethodName(c.getName())
+                        && c.getParameters().size() == 1
+                        && Objects.equals(kClass, c.getParameters().get(0).getType().getClassifier()))
+                .collect(toMap(KCallable::getName, m -> m));
+
+        var mutableProperties = KClasses.getDeclaredMemberProperties(kClass).stream()
+                .filter(p -> p instanceof KMutableProperty)
+                .collect(toMap(KCallable::getName, m -> m));
+
+        List<ReflectField> fields = new ArrayList<>();
+        int n = 1;
+        for (KParameter param : primaryKtConstructor.getParameters()) {
+            var paramName = param.getName();
+
+            Preconditions.checkArgument(!mutableProperties.containsKey(paramName),
+                    "Mutable constructor arguments are not allowed in '%s', but got: '%s'",
+                    kClassName, paramName);
+
+            var callable = functions.get("component" + n);
+            Preconditions.checkState(callable != null,
+                    "Could not find component%s() in '%s'",
+                    n, kClassName);
+            fields.add(new KotlinDataClassComponent(reflector, paramName, callable));
+            n++;
+        }
+        this.fields = List.copyOf(fields);
+    }
+
+    @Override
+    public Constructor<T> getConstructor() {
+        return constructor;
+    }
+
+    @Override
+    public List<ReflectField> getFields() {
+        return fields;
+    }
+
+    @Override
+    public Class<T> getRawType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return "KotlinDataClassType[" + type + "]";
+    }
+}

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassTypeFactory.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassTypeFactory.java
@@ -1,0 +1,57 @@
+package tech.ydb.yoj.databind.schema.reflect;
+
+import kotlin.Metadata;
+import tech.ydb.yoj.databind.FieldValueType;
+import tech.ydb.yoj.databind.schema.reflect.StdReflector.TypeFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import static java.util.Arrays.stream;
+
+public final class KotlinDataClassTypeFactory implements TypeFactory {
+    public static final TypeFactory instance = new KotlinDataClassTypeFactory();
+
+    private static final int KIND_CLASS = 1;
+
+    private KotlinDataClassTypeFactory() {
+    }
+
+    @Override
+    public int priority() {
+        return 300;
+    }
+
+    @Override
+    public boolean matches(Class<?> rawType, FieldValueType fvt) {
+        return KotlinReflectionDetector.kotlinAvailable
+                && stream(rawType.getDeclaredAnnotations()).anyMatch(this::isKotlinClassMetadata)
+                && stream(rawType.getDeclaredMethods()).anyMatch(this::isComponentGetter);
+    }
+
+    private boolean isKotlinClassMetadata(Annotation ann) {
+        return Metadata.class.equals(ann.annotationType()) && ((Metadata) ann).k() == KIND_CLASS;
+    }
+
+    private boolean isComponentGetter(Method m) {
+        return m.getParameterCount() == 0 && isComponentMethodName(m.getName());
+    }
+
+    @Override
+    public <R> ReflectType<R> create(Reflector reflector, Class<R> rawType, FieldValueType fvt) {
+        return new KotlinDataClassType<>(reflector, rawType);
+    }
+
+    static boolean isComponentMethodName(String name) {
+        if (!name.startsWith("component")) {
+            return false;
+        }
+
+        try {
+            int n = Integer.parseInt(name.substring("component".length()), 10);
+            return n >= 1;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinReflectionDetector.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinReflectionDetector.java
@@ -1,0 +1,49 @@
+package tech.ydb.yoj.databind.schema.reflect;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class KotlinReflectionDetector {
+    private static final Logger log = LoggerFactory.getLogger(KotlinReflectionDetector.class);
+
+    private KotlinReflectionDetector() {
+    }
+
+    public static final boolean kotlinAvailable = detectKotlinReflection();
+
+    private static boolean detectKotlinReflection() {
+        var cl = classLoader();
+
+        try {
+            Class.forName("kotlin.Metadata", false, cl);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+
+        try {
+            Class.forName("kotlin.reflect.full.KClasses", false, cl);
+            return true;
+        } catch (ClassNotFoundException e) {
+            log.warn("YOJ has detected Kotlin but not kotlin-reflect. Kotlin data classes won't work as Entities.", e);
+            return false;
+        }
+    }
+
+    private static ClassLoader classLoader() {
+        ClassLoader cl = null;
+        try {
+            cl = Thread.currentThread().getContextClassLoader();
+        } catch (Exception ignore) {
+        }
+        if (cl == null) {
+            cl = KotlinDataClassType.class.getClassLoader();
+            if (cl == null) {
+                try {
+                    cl = ClassLoader.getSystemClassLoader();
+                } catch (Exception ignore) {
+                }
+            }
+        }
+        return cl;
+    }
+}

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/PojoType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/PojoType.java
@@ -63,7 +63,7 @@ public final class PojoType<T> implements ReflectType<T> {
                     .toList();
         } else {
             this.fields = Stream.of(type.getDeclaredFields())
-                    .filter(tech.ydb.yoj.databind.schema.reflect.PojoType::isEntityField)
+                    .filter(PojoType::isEntityField)
                     .<ReflectField>map(f -> new PojoField(reflector, f))
                     .toList();
         }
@@ -94,7 +94,7 @@ public final class PojoType<T> implements ReflectType<T> {
     // FIXME: this is NOT the best way to find all-args ctor
     private static <T> Constructor<T> findAllArgsCtor(Class<T> type) {
         long instanceFieldCount = Stream.of(type.getDeclaredFields())
-                .filter(tech.ydb.yoj.databind.schema.reflect.PojoType::isEntityField)
+                .filter(PojoType::isEntityField)
                 .count();
 
         @SuppressWarnings("unchecked") Constructor<T> ctor = (Constructor<T>) Stream.of(type.getDeclaredConstructors())

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/StdReflector.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/StdReflector.java
@@ -11,8 +11,8 @@ import java.util.List;
 import static java.util.Comparator.comparing;
 
 /**
- * Standard {@link Reflector} implementation, suitable for most usages. By default, reflecting record classes, POJOs and
- * simple types such as {@code int} is supported.
+ * Standard {@link Reflector} implementation, suitable for most usages. By default, reflecting record classes, Kotlin
+ * data classes, POJOs and simple types such as {@code int} is supported.
  * <p>
  * You can override default {@link Reflector} by creating a custom {@link SchemaRegistry} with your own instance of
  * {@code StdReflector} with a different set of {@link TypeFactory type factories}, or a wholly different implementation
@@ -26,6 +26,7 @@ import static java.util.Comparator.comparing;
 public final class StdReflector implements Reflector {
     public static final Reflector instance = new StdReflector(List.of(
             RecordType.FACTORY,
+            KotlinDataClassTypeFactory.instance,
             PojoType.FACTORY,
             SimpleType.FACTORY
     ));

--- a/databind/src/test/kotlin/tech/ydb/yoj/databind/schema/KotlinJvmRecordSchemaTest.kt
+++ b/databind/src/test/kotlin/tech/ydb/yoj/databind/schema/KotlinJvmRecordSchemaTest.kt
@@ -1,0 +1,117 @@
+package tech.ydb.yoj.databind.schema
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.BeforeClass
+import org.junit.Test
+
+class KotlinJvmRecordSchemaTest {
+    @Test
+    fun testRawPathField() {
+        val field = schema!!.getField("entity1")
+
+        assertThat(field.rawPath).isEqualTo("entity1")
+    }
+
+    @Test
+    fun testRawPathSubField() {
+        val field = schema!!.getField("entity1.entity2.entity3")
+
+        assertThat(field.rawPath).isEqualTo("entity1.entity2.entity3")
+    }
+
+    @Test
+    fun testRawPathLeafField() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.rawPath).isEqualTo("entity1.entity2.entity3.value")
+    }
+
+    @Test
+    fun testRawSubPathSubField() {
+        val field = schema!!.getField("entity1.entity2.entity3")
+
+        assertThat(field.getRawSubPath(1)).isEqualTo("entity2.entity3")
+    }
+
+    @Test
+    fun testRawSubPathLeafFieldOnlyLead() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.getRawSubPath(3)).isEqualTo("value")
+    }
+
+    @Test
+    fun testRawSubPathLeafFieldEqualNesting() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.getRawSubPath(4)).isEmpty()
+    }
+
+    @Test
+    fun testRawSubPathLeafFieldExceedsNesting() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.getRawSubPath(10)).isEmpty()
+    }
+
+    @Test
+    fun testIsFlatTrue() {
+        assertThat(schema!!.getField("flatEntity").isFlat).isTrue()
+    }
+
+    @Test
+    fun testIdsFlatFalse() {
+        assertThat(schema!!.getField("twoFieldEntity").isFlat).isFalse()
+    }
+
+    @Test
+    fun testIsFlatFalseForNotFlat() {
+        assertThat(schema!!.getField("notFlatEntity").isFlat).isFalse()
+    }
+
+    private class TestSchema<T>(entityType: Class<T>) : Schema<T>(entityType)
+
+    @JvmRecord
+    private data class UberEntity(
+        val entity1: Entity1,
+        val flatEntity: FlatEntity,
+        val twoFieldEntity: TwoFieldEntity,
+        val notFlatEntity: NotFlatEntity,
+    )
+
+    @JvmRecord
+    private data class Entity1(val entity2: Entity2)
+
+    @JvmRecord
+    private data class Entity2(val entity3: Entity3)
+
+    @JvmRecord
+    private data class Entity3(val value: Int)
+
+    @JvmRecord
+    private data class FlatEntity(val entity1: Entity1)
+
+    @JvmRecord
+    private data class TwoFieldEntity(
+        val entity1: Entity1,
+        val boolValue: Boolean,
+    )
+
+    @JvmRecord
+    private data class NotFlatEntity(
+        val twoFieldEntity: TwoFieldEntity,
+        val otherTwoFieldEntity: TwoFieldEntity,
+    )
+
+    companion object {
+        private var schema: Schema<UberEntity>? = null
+
+        @JvmStatic
+        @BeforeClass
+        fun setUpClass() {
+            schema = TestSchema(
+                UberEntity::class.java
+            )
+        }
+    }
+}

--- a/databind/src/test/kotlin/tech/ydb/yoj/databind/schema/KotlinSchemaTest.kt
+++ b/databind/src/test/kotlin/tech/ydb/yoj/databind/schema/KotlinSchemaTest.kt
@@ -1,0 +1,110 @@
+package tech.ydb.yoj.databind.schema
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.BeforeClass
+import org.junit.Test
+
+class KotlinSchemaTest {
+    @Test
+    fun testRawPathField() {
+        val field = schema!!.getField("entity1")
+
+        assertThat(field.rawPath).isEqualTo("entity1")
+    }
+
+    @Test
+    fun testRawPathSubField() {
+        val field = schema!!.getField("entity1.entity2.entity3")
+
+        assertThat(field.rawPath).isEqualTo("entity1.entity2.entity3")
+    }
+
+    @Test
+    fun testRawPathLeafField() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.rawPath).isEqualTo("entity1.entity2.entity3.value")
+    }
+
+    @Test
+    fun testRawSubPathSubField() {
+        val field = schema!!.getField("entity1.entity2.entity3")
+
+        assertThat(field.getRawSubPath(1)).isEqualTo("entity2.entity3")
+    }
+
+    @Test
+    fun testRawSubPathLeafFieldOnlyLead() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.getRawSubPath(3)).isEqualTo("value")
+    }
+
+    @Test
+    fun testRawSubPathLeafFieldEqualNesting() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.getRawSubPath(4)).isEmpty()
+    }
+
+    @Test
+    fun testRawSubPathLeafFieldExceedsNesting() {
+        val field = schema!!.getField("entity1.entity2.entity3.value")
+
+        assertThat(field.getRawSubPath(10)).isEmpty()
+    }
+
+    @Test
+    fun testIsFlatTrue() {
+        assertThat(schema!!.getField("flatEntity").isFlat).isTrue()
+    }
+
+    @Test
+    fun testIdsFlatFalse() {
+        assertThat(schema!!.getField("twoFieldEntity").isFlat).isFalse()
+    }
+
+    @Test
+    fun testIsFlatFalseForNotFlat() {
+        assertThat(schema!!.getField("notFlatEntity").isFlat).isFalse()
+    }
+
+    private class TestSchema<T>(entityType: Class<T>) : Schema<T>(entityType)
+
+    private data class UberEntity(
+        val entity1: Entity1,
+        val flatEntity: FlatEntity,
+        val twoFieldEntity: TwoFieldEntity,
+        val notFlatEntity: NotFlatEntity,
+    )
+
+    private data class Entity1(val entity2: Entity2)
+
+    private data class Entity2(val entity3: Entity3)
+
+    private data class Entity3(val value: Int)
+
+    private data class FlatEntity(val entity1: Entity1)
+
+    private data class TwoFieldEntity(
+        val entity1: Entity1,
+        val boolValue: Boolean,
+    )
+
+    private data class NotFlatEntity(
+        val twoFieldEntity: TwoFieldEntity,
+        val otherTwoFieldEntity: TwoFieldEntity,
+    )
+
+    companion object {
+        private var schema: Schema<UberEntity>? = null
+
+        @JvmStatic
+        @BeforeClass
+        fun setUpClass() {
+            schema = TestSchema(
+                UberEntity::class.java
+            )
+        }
+    }
+}

--- a/databind/src/test/resources/log4j2.yaml
+++ b/databind/src/test/resources/log4j2.yaml
@@ -1,0 +1,15 @@
+Configuration:
+  appenders:
+    Console:
+      name: stdout
+      PatternLayout:
+        Pattern: "%d %-5level %-6X{tx} [%t] %c{1.}: %msg%n%throwable"
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: stdout
+    Logger:
+    - name: tech.ydb.yoj.databind
+      level: debug

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tech.ydb.yoj</groupId>
     <artifactId>yoj-parent</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>YDB ORM for Java (YOJ)</name>
@@ -130,6 +130,9 @@
         <prometheus.version>0.6.0</prometheus.version>
         <error-prone-annotations.version>2.14.0</error-prone-annotations.version>
         <gson-version>2.10.1</gson-version>
+
+        <!-- optional dependencies (Kotlin support) -->
+        <kotlin.version>1.9.22</kotlin.version>
 
         <!-- test dependencies -->
         <junit.version>4.13.2</junit.version>
@@ -369,6 +372,11 @@
                         <!-- FIXME(entropia@): fix malformed HTML and re-enable doclint -->
                         <doclint>none</doclint>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-maven-plugin</artifactId>
+                    <version>${kotlin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -641,6 +649,18 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-reflect</artifactId>
+                <version>${kotlin.version}</version>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
+                <optional>true</optional>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/repository-inmemory/pom.xml
+++ b/repository-inmemory/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repository-test/pom.xml
+++ b/repository-test/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repository-ydb-common/pom.xml
+++ b/repository-ydb-common/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repository-ydb-v1/pom.xml
+++ b/repository-ydb-v1/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/repository-ydb-v2/pom.xml
+++ b/repository-ydb-v2/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>tech.ydb.yoj</groupId>
             <artifactId>yoj-repository-test</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>tech.ydb.yoj</groupId>
         <artifactId>yoj-parent</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Kotlin support is enabled by default if you have `kotlin-stdlib` *AND* `kotlin-reflection` 1.9.x on your classpath.

Note that you can use Kotlin data classes exposed as Java records (`@JvmRecord`) even if you have *NO* Kotlin dependencies on your classpath.

Fixes: #7