### PR TITLE
Update YOJ dependencies. Remove unneeded test dependency on restito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,15 +110,16 @@
         <ydb-sdk-v1.version>1.14.14</ydb-sdk-v1.version>
 
         <!-- YDB SDK 2.x -->
-        <ydb-sdk-v2.version>2.1.7</ydb-sdk-v2.version>
+        <ydb-sdk-v2.version>2.1.10</ydb-sdk-v2.version>
+        <ydb-proto-api.version>1.6.0</ydb-proto-api.version>
 
         <!-- build-only dependencies (provided) -->
         <lombok.version>1.18.30</lombok.version>
         <checkstyle.version>10.12.4</checkstyle.version>
 
         <!-- compile dependencies -->
-        <protobuf.version>3.21.7</protobuf.version>
-        <grpc.version>1.51.3</grpc.version>
+        <protobuf.version>3.24.0</protobuf.version>
+        <grpc.version>1.59.1</grpc.version>
         <proto-google-common-protos.version>2.9.0</proto-google-common-protos.version>
         <netty.version>4.1.100.Final</netty.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -134,15 +135,13 @@
         <!-- test dependencies -->
         <junit.version>4.13.2</junit.version>
         <hamcrest-core.version>2.2</hamcrest-core.version>
-        <assertj-core.version>3.22.0</assertj-core.version>
+        <assertj-core.version>3.25.1</assertj-core.version>
         <log4j2.version>2.17.2</log4j2.version>
         <mockito.version>5.5.0</mockito.version>
         <!-- NB: testcontainers and docker-java versions are related - when bumping one, check if another needs to be bumped too -->
         <docker-java.version>3.3.3</docker-java.version>
         <testcontainers.version>1.19.1</testcontainers.version>
-        <restito.version>0.9.3</restito.version>
-        <grizzly.version>2.3.25</grizzly.version>
-        <jackson.version>2.14.1</jackson.version>
+        <jackson.version>2.16.1</jackson.version>
         <snakeyaml.version>1.33</snakeyaml.version>
     </properties>
 
@@ -577,6 +576,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>tech.ydb</groupId>
+                <artifactId>ydb-proto-api</artifactId>
+                <version>${ydb-proto-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
@@ -604,21 +608,6 @@
                 <groupId>com.google.api.grpc</groupId>
                 <artifactId>proto-google-common-protos</artifactId>
                 <version>${proto-google-common-protos.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.xebialabs.restito</groupId>
-                <artifactId>restito</artifactId>
-                <version>${restito.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.grizzly</groupId>
-                <artifactId>grizzly-http</artifactId>
-                <version>${grizzly.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.grizzly</groupId>
-                <artifactId>grizzly-http-server</artifactId>
-                <version>${grizzly.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>

--- a/repository-ydb-v1/pom.xml
+++ b/repository-ydb-v1/pom.xml
@@ -91,17 +91,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.xebialabs.restito</groupId>
-            <artifactId>restito</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>json-smart</artifactId>
-                    <groupId>net.minidev</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/repository-ydb-v1/src/test/resources/log4j2.yaml
+++ b/repository-ydb-v1/src/test/resources/log4j2.yaml
@@ -13,10 +13,6 @@ Configuration:
     Logger:
     - name: io.grpc
       level: error
-    - name: com.xebialabs
-      level: error
-    - name: org.glassfish.grizzly
-      level: error
     - name: io.netty
       level: error
     - name: tech.ydb.yoj.repository.db

--- a/repository-ydb-v2/pom.xml
+++ b/repository-ydb-v2/pom.xml
@@ -114,27 +114,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-http</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.grizzly</groupId>
-            <artifactId>grizzly-http-server</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.xebialabs.restito</groupId>
-            <artifactId>restito</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>json-smart</artifactId>
-                    <groupId>net.minidev</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>tech.ydb.test</groupId>
             <artifactId>ydb-junit4-support</artifactId>
             <scope>test</scope>

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
@@ -461,7 +461,9 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
                 .orderedRead(params.isOrdered())
                 .withRequestTimeout(params.getTimeout())
                 .rowLimit(params.getRowLimit())
-                .columns(mapper.getColumns());
+                .columns(mapper.getColumns())
+                .batchLimitBytes(params.getBatchLimitBytes())
+                .batchLimitRows(params.getBatchLimitRows());
         if (params.getFromKey() != null) {
             List<Value<?>> values = mapper.mapKey(params.getFromKey()).stream()
                     .map(typedValue -> YdbConverter.toSDK(typedValue.getType(), typedValue.getValue()))

--- a/repository-ydb-v2/src/test/resources/log4j2.yaml
+++ b/repository-ydb-v2/src/test/resources/log4j2.yaml
@@ -13,10 +13,6 @@ Configuration:
     Logger:
     - name: io.grpc
       level: error
-    - name: com.xebialabs
-      level: error
-    - name: org.glassfish.grizzly
-      level: error
     - name: io.netty
       level: error
     - name: tech.ydb.yoj.repository.db

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/readtable/ReadTableParams.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/readtable/ReadTableParams.java
@@ -19,12 +19,14 @@ public class ReadTableParams<ID> {
 
     boolean useNewSpliterator;
 
+    int batchLimitBytes;
+    int batchLimitRows;
+
     public static <ID> ReadTableParams<ID> getDefault() {
         return ReadTableParams.<ID>builder().build();
     }
 
     public static class ReadTableParamsBuilder<ID> {
-
         public ReadTableParams.ReadTableParamsBuilder<ID> ordered() {
             this.ordered = true;
             return this;


### PR DESCRIPTION
Now we use:
* YDB Java SDK 2.1.7 -> 2.1.10 + new ReadTable settings
* New YDB protobuf artifacts: 1.6.0
* gRPC 1.51.3->1.59.1
* protobuf 3.21.7->3.24.0
* (test) Jackson 2.14.1->2.16.1
* (test) AssertJ 3.22.0->3.25.1

Did not update (vulnerable) snakeyaml 1.33, because it is *ONLY* used in YOJ tests.