### PR TITLE
Stream scan query support

### DIFF
--- a/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
+++ b/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
@@ -353,7 +353,7 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
 
     private <PARAMS, RESULT> List<RESULT> doExecuteScanQueryList(Statement<PARAMS, RESULT> statement, PARAMS params) {
         List<RESULT> result = new ArrayList<>();
-        try (Stream<RESULT> stream = doExecuteScanQuery(statement, params)) {
+        try (Stream<RESULT> stream = executeScanQuery(statement, params)) {
             stream.forEach(r -> {
                 if (result.size() >= options.getScanOptions().getMaxSize()) {
                     throw new ResultTruncatedException(
@@ -367,7 +367,12 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
         return result;
     }
 
-    private <PARAMS, RESULT> Stream<RESULT> doExecuteScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params) {
+    @Override
+    public <PARAMS, RESULT> Stream<RESULT> executeScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params) {
+        if (!options.isScan()) {
+            throw new IllegalStateException("Scan query can be used only from scan tx");
+        }
+        
         ExecuteScanQuerySettings settings = ExecuteScanQuerySettings.newBuilder()
                 .timeout(options.getScanOptions().getTimeout())
                 .mode(com.yandex.ydb.table.YdbTable.ExecuteScanQueryRequest.Mode.MODE_EXEC)

--- a/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/table/YdbTable.java
+++ b/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/table/YdbTable.java
@@ -481,6 +481,8 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
     public interface QueryExecutor {
         <PARAMS, RESULT> List<RESULT> execute(Statement<PARAMS, RESULT> statement, PARAMS params);
 
+        <PARAMS, RESULT> Stream<RESULT> executeScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params);
+
         <PARAMS> void pendingExecute(Statement<PARAMS, ?> statement, PARAMS value);
 
         default <IN> void bulkUpsert(BulkMapper<IN> mapper, List<IN> input, BulkParams params) {
@@ -509,6 +511,11 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
         public <PARAMS, RESULT> List<RESULT> execute(Statement<PARAMS, RESULT> statement, PARAMS params) {
             check();
             return delegate.execute(statement, params);
+        }
+
+        @Override
+        public <PARAMS, RESULT> Stream<RESULT> executeScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params) {
+            return delegate.executeScanQuery(statement, params);
         }
 
         @Override

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
@@ -353,7 +353,7 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
 
     private <PARAMS, RESULT> List<RESULT> doExecuteScanQueryList(Statement<PARAMS, RESULT> statement, PARAMS params) {
         List<RESULT> result = new ArrayList<>();
-        try (Stream<RESULT> stream = doExecuteScanQuery(statement, params)) {
+        try (Stream<RESULT> stream = executeScanQuery(statement, params)) {
             stream.forEach(r -> {
                 if (result.size() >= options.getScanOptions().getMaxSize()) {
                     throw new ResultTruncatedException(
@@ -367,7 +367,12 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
         return result;
     }
 
-    private <PARAMS, RESULT> Stream<RESULT> doExecuteScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params) {
+    @Override
+    public <PARAMS, RESULT> Stream<RESULT> executeScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params) {
+        if (!options.isScan()) {
+            throw new IllegalStateException("Scan query can be used only from scan tx");
+        }
+
         ExecuteScanQuerySettings settings = ExecuteScanQuerySettings.newBuilder()
                 .withRequestTimeout(options.getScanOptions().getTimeout())
                 .setMode(ExecuteScanQuerySettings.Mode.EXEC)

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/table/YdbTable.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/table/YdbTable.java
@@ -481,6 +481,8 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
     public interface QueryExecutor {
         <PARAMS, RESULT> List<RESULT> execute(Statement<PARAMS, RESULT> statement, PARAMS params);
 
+        <PARAMS, RESULT> Stream<RESULT> executeScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params);
+
         <PARAMS> void pendingExecute(Statement<PARAMS, ?> statement, PARAMS value);
 
         default <IN> void bulkUpsert(BulkMapper<IN> mapper, List<IN> input, BulkParams params) {
@@ -509,6 +511,11 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
         public <PARAMS, RESULT> List<RESULT> execute(Statement<PARAMS, RESULT> statement, PARAMS params) {
             check();
             return delegate.execute(statement, params);
+        }
+
+        @Override
+        public <PARAMS, RESULT> Stream<RESULT> executeScanQuery(Statement<PARAMS, RESULT> statement, PARAMS params) {
+            return delegate.executeScanQuery(statement, params);
         }
 
         @Override


### PR DESCRIPTION
Users want to execute scan query on stream. At the moment, they want to execute custom queries, so changes to the Table can be made a little later. It seems to me that this will be the main case for scan query