### PR TITLE
Support private properties in Kotlin data classes

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassComponent.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassComponent.java
@@ -2,6 +2,7 @@ package tech.ydb.yoj.databind.schema.reflect;
 
 import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KCallable;
+import kotlin.reflect.jvm.KCallablesJvm;
 import kotlin.reflect.jvm.ReflectJvmMapping;
 import tech.ydb.yoj.databind.FieldValueType;
 import tech.ydb.yoj.databind.schema.Column;
@@ -26,6 +27,7 @@ public final class KotlinDataClassComponent implements ReflectField {
 
     public KotlinDataClassComponent(Reflector reflector, String name, KCallable<?> callable) {
         this.callable = callable;
+        KCallablesJvm.setAccessible(this.callable, true);
 
         this.name = name;
 

--- a/databind/src/test/kotlin/tech/ydb/yoj/databind/schema/KotlinSchemaTest.kt
+++ b/databind/src/test/kotlin/tech/ydb/yoj/databind/schema/KotlinSchemaTest.kt
@@ -3,6 +3,7 @@ package tech.ydb.yoj.databind.schema
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.BeforeClass
 import org.junit.Test
+import java.util.Map.entry
 
 class KotlinSchemaTest {
     @Test
@@ -69,13 +70,21 @@ class KotlinSchemaTest {
         assertThat(schema!!.getField("notFlatEntity").isFlat).isFalse()
     }
 
+    @Test
+    fun testPrivateProp() {
+        val ue = UberEntity(null, null, null, null, PrivatePropEntity(42))
+        assertThat(schema!!.flatten(ue)).containsOnly(entry("privatePropEntity_privateProp", 42))
+        assertThat(schema!!.newInstance(mapOf("privatePropEntity_privateProp" to 42))).isEqualTo(ue)
+    }
+
     private class TestSchema<T>(entityType: Class<T>) : Schema<T>(entityType)
 
     private data class UberEntity(
-        val entity1: Entity1,
-        val flatEntity: FlatEntity,
-        val twoFieldEntity: TwoFieldEntity,
-        val notFlatEntity: NotFlatEntity,
+        val entity1: Entity1?,
+        val flatEntity: FlatEntity?,
+        val twoFieldEntity: TwoFieldEntity?,
+        val notFlatEntity: NotFlatEntity?,
+        val privatePropEntity: PrivatePropEntity
     )
 
     private data class Entity1(val entity2: Entity2)
@@ -94,6 +103,10 @@ class KotlinSchemaTest {
     private data class NotFlatEntity(
         val twoFieldEntity: TwoFieldEntity,
         val otherTwoFieldEntity: TwoFieldEntity,
+    )
+
+    private data class PrivatePropEntity(
+        private val privateProp: Int
     )
 
     companion object {


### PR DESCRIPTION
YOJ accepts private constructors and uses private fields for POJOs. Do the same for private Kotlin `data class` properties (call `setAccessible()`).