### PR TITLE
ByteArray class for primary keys with byte[]

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/ByteArray.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/ByteArray.java
@@ -1,0 +1,75 @@
+package tech.ydb.yoj.databind;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+public final class ByteArray implements Comparable<ByteArray> {
+    private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+
+    private final byte[] array;
+
+    private ByteArray(byte[] array) {
+        this.array = array;
+    }
+
+    public static ByteArray wrap(byte[] array) {
+        return new ByteArray(array);
+    }
+
+    public static ByteArray copy(byte[] array) {
+        return new ByteArray(array.clone());
+    }
+
+    public byte[] getArray() {
+        return array;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ByteArray that = (ByteArray) o;
+        return Arrays.equals(array, that.array);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(array);
+    }
+
+    @Override
+    public int compareTo(@NotNull ByteArray o) {
+        return Arrays.compare(array, o.array);
+    }
+
+    @Override
+    public String toString() {
+        if (array.length > 16) {
+            return "bytes(length > 16)";
+        }
+
+        char[] hexChars = new char[array.length * 2 + 7];
+        hexChars[0] = 'b';
+        hexChars[1] = 'y';
+        hexChars[2] = 't';
+        hexChars[3] = 'e';
+        hexChars[4] = 's';
+        hexChars[5] = '(';
+
+        int i = 0;
+        for (; i < array.length; i++) {
+            int v = array[i] & 0xFF;
+            int ci = i * 2 + 6;
+            hexChars[ci] = HEX_CHARS[v >>> 4];
+            hexChars[ci + 1] = HEX_CHARS[v & 0x0F];
+        }
+        hexChars[i * 2 + 6] = ')';
+
+        return new String(hexChars);
+    }
+}

--- a/databind/src/main/java/tech/ydb/yoj/databind/ByteArray.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/ByteArray.java
@@ -21,6 +21,10 @@ public final class ByteArray implements Comparable<ByteArray> {
         return new ByteArray(array.clone());
     }
 
+    public ByteArray copy() {
+        return ByteArray.copy(array);
+    }
+
     public byte[] getArray() {
         return array;
     }

--- a/databind/src/main/java/tech/ydb/yoj/databind/FieldValueType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/FieldValueType.java
@@ -63,6 +63,11 @@ public enum FieldValueType {
      */
     BINARY,
     /**
+     * Binary value: just a stream of uninterpreted bytes.
+     * Java-side <strong>must</strong> be a {@link ByteArray tech.ydb.yoj.databind.ByteArray}.
+     */
+    BYTE_ARRAY,
+    /**
      * Composite value. Can contain any other values, including other composite values.<br>
      * Java-side must be an immutable POJO with all-args constructor, e.g. a Lombok {@code @Value}-annotated
      * class.
@@ -80,7 +85,7 @@ public enum FieldValueType {
     UNKNOWN;
 
     private static final Set<FieldValueType> SORTABLE_VALUE_TYPES = Set.of(
-            INTEGER, STRING, ENUM, TIMESTAMP
+            INTEGER, STRING, ENUM, TIMESTAMP, BYTE_ARRAY
     );
 
     private static final Set<Type> INTEGER_NUMERIC_TYPES = Set.of(
@@ -152,6 +157,8 @@ public enum FieldValueType {
                 return INTERVAL;
             } else if (byte[].class.equals(type)) {
                 return BINARY;
+            } else if (ByteArray.class.equals(type)) {
+                return BYTE_ARRAY;
             } else if (Collection.class.isAssignableFrom(clazz)) {
                 throw new IllegalArgumentException("Raw collection types cannot be used in databinding: " + type);
             } else if (Object.class.equals(clazz)) {

--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/FieldValue.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/FieldValue.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import tech.ydb.yoj.databind.ByteArray;
 import tech.ydb.yoj.databind.FieldValueType;
 import tech.ydb.yoj.databind.schema.ObjectSchema;
 import tech.ydb.yoj.databind.schema.Schema.JavaField;
@@ -34,35 +35,41 @@ public class FieldValue {
     Boolean bool;
     Instant timestamp;
     Tuple tuple;
+    ByteArray byteArray;
 
     @NonNull
     public static FieldValue ofStr(@NonNull String str) {
-        return new FieldValue(str, null, null, null, null, null);
+        return new FieldValue(str, null, null, null, null, null, null);
     }
 
     @NonNull
     public static FieldValue ofNum(long num) {
-        return new FieldValue(null, num, null, null, null, null);
+        return new FieldValue(null, num, null, null, null, null, null);
     }
 
     @NonNull
     public static FieldValue ofReal(double real) {
-        return new FieldValue(null, null, real, null, null, null);
+        return new FieldValue(null, null, real, null, null, null, null);
     }
 
     @NonNull
     public static FieldValue ofBool(boolean bool) {
-        return new FieldValue(null, null, null, bool, null, null);
+        return new FieldValue(null, null, null, bool, null, null, null);
     }
 
     @NonNull
     public static FieldValue ofTimestamp(@NonNull Instant timestamp) {
-        return new FieldValue(null, null, null, null, timestamp, null);
+        return new FieldValue(null, null, null, null, timestamp, null, null);
     }
 
     @NonNull
     public static FieldValue ofTuple(@NonNull Tuple tuple) {
-        return new FieldValue(null, null, null, null, null, tuple);
+        return new FieldValue(null, null, null, null, null, tuple, null);
+    }
+
+    @NonNull
+    public static FieldValue ofByteArray(@NonNull ByteArray byteArray) {
+        return new FieldValue(null, null, null, null, null, null, byteArray);
     }
 
     @NonNull
@@ -83,6 +90,9 @@ public class FieldValue {
             }
             case BOOLEAN -> {
                 return ofBool((Boolean) obj);
+            }
+            case BYTE_ARRAY -> {
+                return ofByteArray((ByteArray) obj);
             }
             case TIMESTAMP -> {
                 return ofTimestamp((Instant) obj);
@@ -131,6 +141,10 @@ public class FieldValue {
 
     public boolean isTuple() {
         return tuple != null;
+    }
+
+    public boolean isByteArray() {
+        return byteArray != null;
     }
 
     @Nullable
@@ -200,6 +214,10 @@ public class FieldValue {
             case BOOLEAN -> {
                 Preconditions.checkState(isBool(), "Value is not a boolean: %s", this);
                 return bool;
+            }
+            case BYTE_ARRAY -> {
+                Preconditions.checkState(isByteArray(), "Value is not a ByteArray: %s", this);
+                return byteArray;
             }
             case COMPOSITE -> {
                 Preconditions.checkState(isTuple(), "Value is not a tuple: %s", this);

--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/IllegalExpressionException.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/IllegalExpressionException.java
@@ -56,6 +56,12 @@ public abstract class IllegalExpressionException extends IllegalArgumentExceptio
             }
         }
 
+        static final class ByteArrayFieldExpected extends FieldTypeError {
+            ByteArrayFieldExpected(String field) {
+                super(field, "Type mismatch: cannot compare field \"%s\" with a ByteArray value"::formatted);
+            }
+        }
+
         static final class DateTimeFieldExpected extends FieldTypeError {
             DateTimeFieldExpected(String field) {
                 super(field, "Type mismatch: cannot compare field \"%s\" with a date-time value"::formatted);

--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/ModelField.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/ModelField.java
@@ -100,7 +100,7 @@ public final class ModelField {
         } else if (value.isByteArray()) {
             checkArgument(fieldValueType == FieldValueType.BYTE_ARRAY,
                     ByteArrayFieldExpected::new,
-                    p -> format("Specified a boolean value for non-boolean field \"%s\"", p));
+                    p -> format("Specified a ByteArray value for non-ByteArray field \"%s\"", p));
         } else if (value.isTimestamp()) {
             checkArgument(fieldValueType == FieldValueType.TIMESTAMP || fieldValueType == FieldValueType.INTEGER,
                     DateTimeFieldExpected::new,

--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/ModelField.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/ModelField.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import tech.ydb.yoj.databind.FieldValueType;
 import tech.ydb.yoj.databind.expression.IllegalExpressionException.FieldTypeError.BooleanFieldExpected;
+import tech.ydb.yoj.databind.expression.IllegalExpressionException.FieldTypeError.ByteArrayFieldExpected;
 import tech.ydb.yoj.databind.expression.IllegalExpressionException.FieldTypeError.DateTimeFieldExpected;
 import tech.ydb.yoj.databind.expression.IllegalExpressionException.FieldTypeError.FlatFieldExpected;
 import tech.ydb.yoj.databind.expression.IllegalExpressionException.FieldTypeError.IntegerFieldExpected;
@@ -95,6 +96,10 @@ public final class ModelField {
         } else if (value.isBool()) {
             checkArgument(fieldValueType == FieldValueType.BOOLEAN,
                     BooleanFieldExpected::new,
+                    p -> format("Specified a boolean value for non-boolean field \"%s\"", p));
+        } else if (value.isByteArray()) {
+            checkArgument(fieldValueType == FieldValueType.BYTE_ARRAY,
+                    ByteArrayFieldExpected::new,
                     p -> format("Specified a boolean value for non-boolean field \"%s\"", p));
         } else if (value.isTimestamp()) {
             checkArgument(fieldValueType == FieldValueType.TIMESTAMP || fieldValueType == FieldValueType.INTEGER,

--- a/databind/src/test/java/tech/ydb/yoj/databind/ByteArrayTest.java
+++ b/databind/src/test/java/tech/ydb/yoj/databind/ByteArrayTest.java
@@ -1,0 +1,103 @@
+package tech.ydb.yoj.databind;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.TreeSet;
+
+public class ByteArrayTest {
+    @Test
+    public void testWrap() {
+        byte[] arr = bytesOf(0, 1, 2);
+        var b = ByteArray.wrap(arr);
+        b.getArray()[1] = 3;
+
+        Assert.assertEquals(arr[1], 3);
+    }
+
+    @Test
+    public void testCopy() {
+        byte[] arr = bytesOf(0, 1, 2);
+        var b = ByteArray.copy(arr);
+        b.getArray()[1] = 3;
+
+        Assert.assertEquals(arr[1], 1);
+    }
+
+    @Test
+    public void testEquals() {
+        byte[] arrA = bytesOf(0, 1, 2);
+        byte[] arrB = bytesOf(0, 1, 2);
+        var a = ByteArray.wrap(arrA);
+        var b = ByteArray.wrap(arrB);
+
+        Assert.assertNotEquals(arrA, arrB);
+        Assert.assertEquals(a, a);
+        Assert.assertEquals(a, b);
+        Assert.assertNotEquals(a, null);
+    }
+
+    @Test
+    public void testSetWork() {
+        TreeSet<ByteArray> set = new TreeSet<>(List.of(
+                valueOf(0, 1, 2),
+                valueOf(0, 1, 2),
+                valueOf(),
+                valueOf(255),
+                valueOf(1, 2, 3),
+                valueOf(1, 2, 3),
+                valueOf(0, 1, 3)
+        ));
+
+        Assert.assertEquals(set.stream().toList(), List.of(
+                valueOf(),
+                valueOf(255),
+                valueOf(0, 1, 2),
+                valueOf(0, 1, 3),
+                valueOf(1, 2, 3)
+        ));
+    }
+
+    @Test
+    public void testCompare() {
+        Assert.assertEquals(0, valueOf(0, 1, 2).compareTo(valueOf(0, 1, 2)));
+        Assert.assertEquals(1, valueOf(0, 1, 3).compareTo(valueOf(0, 1, 2)));
+        Assert.assertTrue(0 > valueOf(0, 1, 2).compareTo(valueOf(1, 2, 3)));
+        Assert.assertTrue(0 > valueOf().compareTo(valueOf(1, 2, 3)));
+        Assert.assertTrue(0 < valueOf(1, 2, 3).compareTo(valueOf()));
+        Assert.assertTrue(0 < valueOf(0, 1, 2).compareTo(valueOf(0, 1)));
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("bytes()", valueOf().toString());
+        Assert.assertEquals("bytes(00)", valueOf(0).toString());
+        Assert.assertEquals("bytes(0102ff)", valueOf(1, 2, 255).toString());
+        Assert.assertEquals("bytes(00a2fe00)", valueOf(0, 162, 254, 0).toString());
+        Assert.assertEquals(
+                "bytes(01010101010101010101010101010101)",
+                valueOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1).toString()
+        );
+        Assert.assertEquals(
+                "bytes(length > 16)",
+                valueOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1).toString()
+        );
+    }
+
+    private static byte[] bytesOf(int... array) {
+        byte[] result = new byte[array.length];
+        for (int i = 0; i < array.length; i++) {
+            result[i] = (byte) array[i];
+        }
+        return result;
+    }
+
+    private static ByteArray valueOf(int... array) {
+        byte[] result = new byte[array.length];
+        for (int i = 0; i < array.length; i++) {
+            result[i] = (byte) array[i];
+        }
+        return ByteArray.wrap(result);
+    }
+}

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
@@ -104,7 +104,7 @@ final class Columns {
                         : CommonConverters.deserializeEnumValue(type, value);
                 case OBJECT -> CommonConverters.deserializeOpaqueObjectValue(type, value);
                 case BINARY -> ((byte[]) value).clone();
-                case BYTE_ARRAY -> ((ByteArray) value).copy().getArray();
+                case BYTE_ARRAY -> ByteArray.copy((byte[]) value);
                 case BOOLEAN, INTEGER, REAL -> value;
                 // TODO: Unify Instant and Duration handling in InMemory and YDB Repository
                 case INTERVAL, TIMESTAMP -> value;

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
@@ -78,7 +78,7 @@ final class Columns {
                         : CommonConverters.serializeEnumValue(type, value);
                 case OBJECT -> CommonConverters.serializeOpaqueObjectValue(type, value);
                 case BINARY -> ((byte[]) value).clone();
-                case BYTE_ARRAY -> ByteArray.copy(((ByteArray) value).getArray());
+                case BYTE_ARRAY -> ((ByteArray) value).copy().getArray();
                 case BOOLEAN, INTEGER, REAL -> value;
                 // TODO: Unify Instant and Duration handling in InMemory and YDB Repository
                 case INTERVAL, TIMESTAMP -> value;
@@ -104,7 +104,7 @@ final class Columns {
                         : CommonConverters.deserializeEnumValue(type, value);
                 case OBJECT -> CommonConverters.deserializeOpaqueObjectValue(type, value);
                 case BINARY -> ((byte[]) value).clone();
-                case BYTE_ARRAY -> ByteArray.copy(((ByteArray) value).getArray());
+                case BYTE_ARRAY -> ((ByteArray) value).copy().getArray();
                 case BOOLEAN, INTEGER, REAL -> value;
                 // TODO: Unify Instant and Duration handling in InMemory and YDB Repository
                 case INTERVAL, TIMESTAMP -> value;

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.eclipse.collections.api.map.ImmutableMap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Maps;
+import tech.ydb.yoj.databind.ByteArray;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.repository.DbTypeQualifier;
 import tech.ydb.yoj.repository.db.Entity;
@@ -77,6 +78,7 @@ final class Columns {
                         : CommonConverters.serializeEnumValue(type, value);
                 case OBJECT -> CommonConverters.serializeOpaqueObjectValue(type, value);
                 case BINARY -> ((byte[]) value).clone();
+                case BYTE_ARRAY -> ByteArray.copy(((ByteArray) value).getArray());
                 case BOOLEAN, INTEGER, REAL -> value;
                 // TODO: Unify Instant and Duration handling in InMemory and YDB Repository
                 case INTERVAL, TIMESTAMP -> value;
@@ -102,6 +104,7 @@ final class Columns {
                         : CommonConverters.deserializeEnumValue(type, value);
                 case OBJECT -> CommonConverters.deserializeOpaqueObjectValue(type, value);
                 case BINARY -> ((byte[]) value).clone();
+                case BYTE_ARRAY -> ByteArray.copy(((ByteArray) value).getArray());
                 case BOOLEAN, INTEGER, REAL -> value;
                 // TODO: Unify Instant and Duration handling in InMemory and YDB Repository
                 case INTERVAL, TIMESTAMP -> value;

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
@@ -34,6 +34,7 @@ import tech.ydb.yoj.repository.test.sample.TestDbImpl;
 import tech.ydb.yoj.repository.test.sample.TestEntityOperations;
 import tech.ydb.yoj.repository.test.sample.model.Book;
 import tech.ydb.yoj.repository.test.sample.model.Bubble;
+import tech.ydb.yoj.repository.test.sample.model.BytePkEntity;
 import tech.ydb.yoj.repository.test.sample.model.Complex;
 import tech.ydb.yoj.repository.test.sample.model.Complex.Id;
 import tech.ydb.yoj.repository.test.sample.model.EntityWithValidation;
@@ -2230,6 +2231,36 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         .orderBy(ob -> ob.orderBy("id").descending())
                         .find())
         ).containsExactly(c2, c1);
+    }
+
+    @Test
+    public void byteIdLessThan() {
+        BytePkEntity e0 = BytePkEntity.valueOf();
+        BytePkEntity e1 = BytePkEntity.valueOf(1, 2, 3);
+        BytePkEntity e2 = BytePkEntity.valueOf(1, 2, 4);
+        BytePkEntity e3 = BytePkEntity.valueOf(1, 3, 255);
+        db.tx(() -> db.bytePkEntities().insert(e0, e1, e2, e3));
+
+        assertThat(db.tx(() -> db.bytePkEntities().query()
+                .where("id").lt(e3.getId())
+                .orderBy(ob -> ob.orderBy("id").descending())
+                .find()
+        )).containsExactly(e2, e1, e0);
+    }
+
+    @Test
+    public void byteIdGreaterThan() {
+        BytePkEntity e0 = BytePkEntity.valueOf();
+        BytePkEntity e1 = BytePkEntity.valueOf(1, 2, 3);
+        BytePkEntity e2 = BytePkEntity.valueOf(1, 2, 4);
+        BytePkEntity e3 = BytePkEntity.valueOf(1, 3, 255);
+        db.tx(() -> db.bytePkEntities().insert(e0, e1, e2, e3));
+
+        assertThat(db.tx(() -> db.bytePkEntities().query()
+                .where("id").gt(e1.getId())
+                .orderBy(ob -> ob.orderBy("id").ascending())
+                .find()
+        )).containsExactly(e2, e3);
     }
 
     @Test

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
@@ -2264,6 +2264,14 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     }
 
     @Test
+    public void byteIdEmpty() {
+        BytePkEntity e0 = BytePkEntity.valueOf();
+        db.tx(() -> db.bytePkEntities().insert(e0));
+
+        assertThat(db.tx(() -> db.bytePkEntities().find(e0.getId()))).isEqualTo(e0);
+    }
+
+    @Test
     public void complexIdLessThanWithEmbeddedId() {
         Supabubble sa = new Supabubble(new Supabubble.Id(new Project.Id("naher"), "bubble-A"));
         Supabubble sb = new Supabubble(new Supabubble.Id(new Project.Id("naher"), "bubble-B"));

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/entity/TestEntities.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/entity/TestEntities.java
@@ -6,6 +6,7 @@ import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.Repository;
 import tech.ydb.yoj.repository.test.sample.model.Book;
 import tech.ydb.yoj.repository.test.sample.model.Bubble;
+import tech.ydb.yoj.repository.test.sample.model.BytePkEntity;
 import tech.ydb.yoj.repository.test.sample.model.Complex;
 import tech.ydb.yoj.repository.test.sample.model.EntityWithValidation;
 import tech.ydb.yoj.repository.test.sample.model.IndexedEntity;
@@ -31,6 +32,7 @@ public final class TestEntities {
             Project.class, TypeFreak.class, Complex.class, Referring.class, Primitive.class,
             Book.class, Book.ByAuthor.class, Book.ByTitle.class,
             LogEntry.class, Team.class,
+            BytePkEntity.class,
             EntityWithValidation.class,
             Bubble.class,
             IndexedEntity.class,

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/TestEntityOperations.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/TestEntityOperations.java
@@ -7,6 +7,7 @@ import tech.ydb.yoj.repository.db.Table;
 import tech.ydb.yoj.repository.db.TableQueryBuilder;
 import tech.ydb.yoj.repository.db.bulk.BulkParams;
 import tech.ydb.yoj.repository.test.sample.model.Bubble;
+import tech.ydb.yoj.repository.test.sample.model.BytePkEntity;
 import tech.ydb.yoj.repository.test.sample.model.Complex;
 import tech.ydb.yoj.repository.test.sample.model.EntityWithValidation;
 import tech.ydb.yoj.repository.test.sample.model.IndexedEntity;
@@ -33,6 +34,10 @@ public interface TestEntityOperations extends BaseDb {
     BubbleTable bubbles();
 
     ComplexTable complexes();
+
+    default Table<BytePkEntity> bytePkEntities() {
+        return table(BytePkEntity.class);
+    }
 
     TypeFreakTable typeFreaks();
 

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/BytePkEntity.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/BytePkEntity.java
@@ -1,0 +1,21 @@
+package tech.ydb.yoj.repository.test.sample.model;
+
+import tech.ydb.yoj.databind.ByteArray;
+import tech.ydb.yoj.repository.db.RecordEntity;
+
+public record BytePkEntity(
+        Id id
+) implements RecordEntity<BytePkEntity> {
+    public record Id(
+            ByteArray array
+    ) implements RecordEntity.Id<BytePkEntity> {
+    }
+
+    public static BytePkEntity valueOf(int... array) {
+        byte[] result = new byte[array.length];
+        for (int i = 0; i < array.length; i++) {
+            result[i] = (byte) array[i];
+        }
+        return new BytePkEntity(new Id(ByteArray.wrap(result)));
+    }
+}

--- a/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlPrimitiveType.java
+++ b/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlPrimitiveType.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.With;
+import tech.ydb.yoj.databind.ByteArray;
 import tech.ydb.yoj.databind.FieldValueType;
 import tech.ydb.yoj.databind.schema.Column;
 import tech.ydb.yoj.databind.schema.Schema.JavaField;
@@ -78,6 +79,7 @@ public class YqlPrimitiveType implements YqlType {
     private static final Setter STRING_SETTER = (b, v) -> b.setBytesValue(ByteString.copyFromUtf8((String) v));
     private static final Setter TEXT_SETTER = (b, v) -> b.setTextValue((String) v);
     private static final Setter BYTES_SETTER = (b, v) -> b.setBytesValue(UnsafeByteOperations.unsafeWrap((byte[]) v));
+    private static final Setter BYTE_ARRAY_SETTER = (b, v) -> b.setBytesValue(UnsafeByteOperations.unsafeWrap(((ByteArray) v).getArray()));
 
     private static final Setter INSTANT_SETTER = (b, v) -> b.setInt64Value(((Instant) v).toEpochMilli());
     private static final Setter INSTANT_UINT_SETTER = (b, v) -> b.setUint64Value(((Instant) v).toEpochMilli());
@@ -115,6 +117,7 @@ public class YqlPrimitiveType implements YqlType {
     private static final Getter STRING_GETTER = v -> v.getBytesValue().toStringUtf8();
     private static final Getter TEXT_GETTER = ValueProtos.Value::getTextValue;
     private static final Getter BYTES_GETTER = v -> v.getBytesValue().toByteArray();
+    private static final Getter BYTE_ARRAY_GETTER = v -> ByteArray.wrap(v.getBytesValue().toByteArray());
 
     private static final Getter INSTANT_GETTER = v -> Instant.ofEpochMilli(v.getInt64Value());
     private static final Getter INSTANT_UINT_GETTER = v -> Instant.ofEpochMilli(v.getUint64Value());
@@ -160,6 +163,7 @@ public class YqlPrimitiveType implements YqlType {
         registerYqlType(Float.class, PrimitiveTypeId.FLOAT, null, true, FLOAT_SETTER, FLOAT_GETTER);
         registerYqlType(Double.class, PrimitiveTypeId.DOUBLE, null, true, DOUBLE_SETTER, DOUBLE_GETTER);
         registerYqlType(byte[].class, PrimitiveTypeId.STRING, null, true, BYTES_SETTER, BYTES_GETTER);
+        registerYqlType(ByteArray.class, PrimitiveTypeId.STRING, null, true, BYTE_ARRAY_SETTER, BYTE_ARRAY_GETTER);
         registerYqlType(Instant.class, PrimitiveTypeId.INT64, DbTypeQualifier.MILLISECONDS, true, INSTANT_SETTER, INSTANT_GETTER);
         registerYqlType(Instant.class, PrimitiveTypeId.UINT64, DbTypeQualifier.MILLISECONDS, false, INSTANT_UINT_SETTER, INSTANT_UINT_GETTER);
         registerYqlType(Instant.class, PrimitiveTypeId.INT64, DbTypeQualifier.SECONDS, false, INSTANT_SECOND_SETTER, INSTANT_SECOND_GETTER);

--- a/repository-ydb-v1/src/test/java/tech/ydb/yoj/repository/ydb/TestYdbRepository.java
+++ b/repository-ydb-v1/src/test/java/tech/ydb/yoj/repository/ydb/TestYdbRepository.java
@@ -16,6 +16,7 @@ import tech.ydb.yoj.repository.test.sample.TestEntityOperations.ComplexTable;
 import tech.ydb.yoj.repository.test.sample.TestEntityOperations.IndexedTable;
 import tech.ydb.yoj.repository.test.sample.TestEntityOperations.Supabubble2Table;
 import tech.ydb.yoj.repository.test.sample.model.Bubble;
+import tech.ydb.yoj.repository.test.sample.model.BytePkEntity;
 import tech.ydb.yoj.repository.test.sample.model.Complex;
 import tech.ydb.yoj.repository.test.sample.model.EntityWithValidation;
 import tech.ydb.yoj.repository.test.sample.model.IndexedEntity;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlPrimitiveType.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlPrimitiveType.java
@@ -12,6 +12,7 @@ import tech.ydb.proto.ValueProtos;
 import tech.ydb.proto.ValueProtos.Type.PrimitiveTypeId;
 import tech.ydb.proto.ValueProtos.Value.ValueCase;
 import tech.ydb.table.values.proto.ProtoValue;
+import tech.ydb.yoj.databind.ByteArray;
 import tech.ydb.yoj.databind.FieldValueType;
 import tech.ydb.yoj.databind.schema.Column;
 import tech.ydb.yoj.databind.schema.Schema.JavaField;
@@ -78,6 +79,7 @@ public class YqlPrimitiveType implements YqlType {
     private static final Setter STRING_SETTER = (b, v) -> b.setBytesValue(ByteString.copyFromUtf8((String) v));
     private static final Setter TEXT_SETTER = (b, v) -> b.setTextValue((String) v);
     private static final Setter BYTES_SETTER = (b, v) -> b.setBytesValue(UnsafeByteOperations.unsafeWrap((byte[]) v));
+    private static final Setter BYTE_ARRAY_SETTER = (b, v) -> b.setBytesValue(UnsafeByteOperations.unsafeWrap(((ByteArray) v).getArray()));
 
     private static final Setter INSTANT_SETTER = (b, v) -> b.setInt64Value(((Instant) v).toEpochMilli());
     private static final Setter INSTANT_UINT_SETTER = (b, v) -> b.setUint64Value(((Instant) v).toEpochMilli());
@@ -115,6 +117,7 @@ public class YqlPrimitiveType implements YqlType {
     private static final Getter STRING_GETTER = v -> v.getBytesValue().toStringUtf8();
     private static final Getter TEXT_GETTER = ValueProtos.Value::getTextValue;
     private static final Getter BYTES_GETTER = v -> v.getBytesValue().toByteArray();
+    private static final Getter BYTE_ARRAY_GETTER = v -> ByteArray.wrap(v.getBytesValue().toByteArray());
 
     private static final Getter INSTANT_GETTER = v -> Instant.ofEpochMilli(v.getInt64Value());
     private static final Getter INSTANT_UINT_GETTER = v -> Instant.ofEpochMilli(v.getUint64Value());
@@ -160,6 +163,7 @@ public class YqlPrimitiveType implements YqlType {
         registerYqlType(Float.class, PrimitiveTypeId.FLOAT, null, true, FLOAT_SETTER, FLOAT_GETTER);
         registerYqlType(Double.class, PrimitiveTypeId.DOUBLE, null, true, DOUBLE_SETTER, DOUBLE_GETTER);
         registerYqlType(byte[].class, PrimitiveTypeId.STRING, null, true, BYTES_SETTER, BYTES_GETTER);
+        registerYqlType(ByteArray.class, PrimitiveTypeId.STRING, null, true, BYTE_ARRAY_SETTER, BYTE_ARRAY_GETTER);
         registerYqlType(Instant.class, PrimitiveTypeId.INT64, DbTypeQualifier.MILLISECONDS, true, INSTANT_SETTER, INSTANT_GETTER);
         registerYqlType(Instant.class, PrimitiveTypeId.UINT64, DbTypeQualifier.MILLISECONDS, false, INSTANT_UINT_SETTER, INSTANT_UINT_GETTER);
         registerYqlType(Instant.class, PrimitiveTypeId.INT64, DbTypeQualifier.SECONDS, false, INSTANT_SECOND_SETTER, INSTANT_SECOND_GETTER);

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/EntityIdSchema.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/EntityIdSchema.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static tech.ydb.yoj.databind.FieldValueType.BOOLEAN;
+import static tech.ydb.yoj.databind.FieldValueType.BYTE_ARRAY;
 import static tech.ydb.yoj.databind.FieldValueType.ENUM;
 import static tech.ydb.yoj.databind.FieldValueType.INTEGER;
 import static tech.ydb.yoj.databind.FieldValueType.STRING;
@@ -49,7 +50,9 @@ public final class EntityIdSchema<ID extends Entity.Id<?>> extends Schema<ID> im
 
     private static final Type ENTITY_TYPE_PARAMETER = Entity.Id.class.getTypeParameters()[0];
 
-    private static final Set<FieldValueType> ALLOWED_ID_FIELD_TYPES = Set.of(STRING, INTEGER, ENUM, BOOLEAN, TIMESTAMP);
+    private static final Set<FieldValueType> ALLOWED_ID_FIELD_TYPES = Set.of(
+            STRING, INTEGER, ENUM, BOOLEAN, TIMESTAMP, BYTE_ARRAY
+    );
 
     private <E extends Entity<E>> EntityIdSchema(EntitySchema<E> entitySchema) {
         super(entitySchema, ID_FIELD_NAME);


### PR DESCRIPTION
Byte arrays in primary keys support.

We can't do it with simple byte[], because records default comparator and equals uses compare adresses, not real data. Special class for this looks better, than magic over byte[]