### PR TITLE
spliterator-bugfix: Spliterator fix

### DIFF
--- a/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
+++ b/repository-ydb-v1/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
@@ -119,6 +119,10 @@ class YdbSpliterator<V> implements Spliterator<V> {
     @Override
     // (stream thread) called from stream engine for get new value.
     public boolean tryAdvance(Consumer<? super V> action) {
+        if (closed) {
+            throw new IllegalStateException("Can't use closed YdbSpliterator");
+        }
+
         // Stream API can call tryAdvance() once again even if tryAdvance() returned false
         if (endData) {
             return false;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
@@ -120,6 +120,10 @@ public class YdbSpliterator<V> implements Spliterator<V> {
     @Override
     // (stream thread) called from stream engine for get new value.
     public boolean tryAdvance(Consumer<? super V> action) {
+        if (closed) {
+            throw new IllegalStateException("Can't use closed YdbSpliterator");
+        }
+
         // Stream API can call tryAdvance() once again even if tryAdvance() returned false
         if (endData) {
             return false;


### PR DESCRIPTION
Previously, we not colose the sliterator, but the Stream, which caused the test that checks what cannot be read from a closed stream to break.