### PR TITLE
#58: `repository-ydb-v2`: Defer initialization of YDB GRPC transport from `YdbRepository` constructor to first usage

### DIFF
--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/LazyGrpcTransport.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/LazyGrpcTransport.java
@@ -1,0 +1,64 @@
+package tech.ydb.yoj.repository.ydb;
+
+import io.grpc.MethodDescriptor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import tech.ydb.core.Result;
+import tech.ydb.core.grpc.GrpcReadStream;
+import tech.ydb.core.grpc.GrpcReadWriteStream;
+import tech.ydb.core.grpc.GrpcRequestSettings;
+import tech.ydb.core.grpc.GrpcTransport;
+import tech.ydb.core.grpc.GrpcTransportBuilder;
+import tech.ydb.yoj.util.function.MoreSuppliers;
+import tech.ydb.yoj.util.function.MoreSuppliers.CloseableMemoizer;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+/**
+ * Lazily constructed YDB SDK {@link GrpcTransport}, to defer testing the YDB connection to actual first usage of {@link YdbRepository},
+ * instead of the {@link YdbRepository} constructor.
+ */
+@RequiredArgsConstructor
+/*package*/ final class LazyGrpcTransport implements GrpcTransport {
+    @Getter
+    private final String database;
+
+    private final CloseableMemoizer<GrpcTransport> transport;
+
+    /*package*/ LazyGrpcTransport(GrpcTransportBuilder builder, Function<GrpcTransportBuilder, GrpcTransport> init) {
+        this.database = builder.getDatabase();
+        this.transport = MoreSuppliers.memoizeCloseable(() -> init.apply(builder));
+    }
+
+    @Override
+    public <ReqT, RespT> CompletableFuture<Result<RespT>> unaryCall(MethodDescriptor<ReqT, RespT> method, GrpcRequestSettings settings, ReqT request) {
+        return transport.get().unaryCall(method, settings, request);
+    }
+
+    @Override
+    public <ReqT, RespT> GrpcReadStream<RespT> readStreamCall(MethodDescriptor<ReqT, RespT> method, GrpcRequestSettings settings, ReqT request) {
+        return transport.get().readStreamCall(method, settings, request);
+    }
+
+    @Override
+    public <ReqT, RespT> GrpcReadWriteStream<RespT, ReqT> readWriteStreamCall(MethodDescriptor<ReqT, RespT> method, GrpcRequestSettings settings) {
+        return transport.get().readWriteStreamCall(method, settings);
+    }
+
+    @Override
+    public ScheduledExecutorService getScheduler() {
+        return transport.get().getScheduler();
+    }
+
+    @Override
+    public void close() {
+        transport.close();
+    }
+
+    @Override
+    public String toString() {
+        return "LazyGrpcTransport[transport created: " + transport.isInitialized() + "]";
+    }
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/SessionManager.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/SessionManager.java
@@ -2,7 +2,7 @@ package tech.ydb.yoj.repository.ydb.client;
 
 import tech.ydb.table.Session;
 
-public interface SessionManager {
+public interface SessionManager extends AutoCloseable {
     Session getSession();
 
     void release(Session session);
@@ -12,6 +12,11 @@ public interface SessionManager {
     void invalidateAllSessions();
 
     void shutdown();
+
+    @Override
+    default void close() {
+        shutdown();
+    }
 
     default boolean healthCheck() {
         return true;

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
@@ -886,6 +886,17 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
         repository.schema(HintAutoPartitioningByLoad.class).create();
     }
 
+    @Test
+    public void creatingRepositoryDoesNotConnect() {
+        YdbConfig intentionallyBadConfig = YdbConfig
+                .createForTesting("must-not-connect", 44444, "/nothing/here/", "/nothing")
+                // This forces YDB SDK to connect at GrpcTransport creation
+                .withUseSingleChannelTransport(false);
+
+        YdbRepository repository = new TestYdbRepository(intentionallyBadConfig);
+        repository.shutdown();
+    }
+
     @AllArgsConstructor
     private static class DelegateSchemeServiceImplBase extends SchemeServiceGrpc.SchemeServiceImplBase {
         @Delegate

--- a/util/src/main/java/tech/ydb/yoj/util/function/MoreSuppliers.java
+++ b/util/src/main/java/tech/ydb/yoj/util/function/MoreSuppliers.java
@@ -1,0 +1,49 @@
+package tech.ydb.yoj.util.function;
+
+import com.google.common.base.Supplier;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+public final class MoreSuppliers {
+    private MoreSuppliers() {
+    }
+
+    public static <T extends AutoCloseable> CloseableMemoizer<T> memoizeCloseable(Supplier<T> supplier) {
+        return new CloseableMemoizer<>(supplier);
+    }
+
+    @RequiredArgsConstructor
+    public static final class CloseableMemoizer<T extends AutoCloseable> implements Supplier<T>, AutoCloseable {
+        private final Supplier<T> delegate;
+        private volatile T value;
+
+        @Override
+        public T get() {
+            if (value == null) {
+                synchronized (this) {
+                    if (value == null) {
+                        return value = delegate.get();
+                    }
+                }
+            }
+            return value;
+        }
+
+        public boolean isInitialized() {
+            return value != null;
+        }
+
+        @Override
+        @SneakyThrows
+        public void close() {
+            if (value != null) {
+                value.close();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "MoreSuppliers.memoizeCloseable(" + (value != null ? "<supplier that returned " + value + ">" : delegate) + ")";
+        }
+    }
+}


### PR DESCRIPTION
This way we don't initialize the GRPC transport and session manager before we need them.