### PR TITLE
Better spliterator

### DIFF
--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
@@ -380,7 +380,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     }
 
     private static <ID extends Entity.Id<?>> ReadTableParams.ReadTableParamsBuilder<ID> buildReadTableParamsNonLegacy() {
-        return ReadTableParams.<ID>builder().useNewSpliterator(true);
+        return ReadTableParams.<ID>builder().spliteratorType(ReadTableParams.SpliteratorType.EXPERIMENTAL);
     }
 
     @Test

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/ClosableSpliterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/ClosableSpliterator.java
@@ -1,0 +1,7 @@
+package tech.ydb.yoj.repository.ydb.spliterator;
+
+import java.util.Spliterator;
+
+public interface ClosableSpliterator<V> extends Spliterator<V> {
+    void close();
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/ResultSetIterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/ResultSetIterator.java
@@ -1,0 +1,73 @@
+package tech.ydb.yoj.repository.ydb.spliterator;
+
+import tech.ydb.proto.ValueProtos;
+import tech.ydb.table.result.ResultSetReader;
+import tech.ydb.yoj.repository.ydb.client.YdbConverter;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public final class ResultSetIterator<V> implements Iterator<V> {
+    private final ResultSetReader resultSet;
+    private final ResultConverter<V> converter;
+    private final List<ValueProtos.Column> columns;
+
+    private int position = 0;
+
+    public ResultSetIterator(ResultSetReader resultSet, ResultConverter<V> converter) {
+        List<ValueProtos.Column> columns;
+        if (resultSet.getRowCount() > 0) {
+            resultSet.setRowIndex(0);
+            columns = getColumns(resultSet);
+        } else {
+            columns = new ArrayList<>();
+        }
+
+        this.resultSet = resultSet;
+        this.converter = converter;
+        this.columns = columns;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return position < resultSet.getRowCount();
+    }
+
+    @Override
+    public V next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        ValueProtos.Value value = buildValue(position++);
+
+        return converter.convert(columns, value);
+    }
+
+    private ValueProtos.Value buildValue(int rowIndex) {
+        resultSet.setRowIndex(rowIndex);
+        ValueProtos.Value.Builder value = ValueProtos.Value.newBuilder();
+        for (int i = 0; i < columns.size(); i++) {
+            value.addItems(YdbConverter.convertValueToProto(resultSet.getColumn(i)));
+        }
+        return value.build();
+    }
+
+    private static List<ValueProtos.Column> getColumns(ResultSetReader resultSet) {
+        List<ValueProtos.Column> columns = new ArrayList<>();
+        for (int i = 0; i < resultSet.getColumnCount(); i++) {
+            columns.add(ValueProtos.Column.newBuilder()
+                    .setName(resultSet.getColumnName(i))
+                    .build()
+            );
+        }
+        return columns;
+    }
+
+    @FunctionalInterface
+    public interface ResultConverter<V> {
+        V convert(List<ValueProtos.Column> columns, ValueProtos.Value value);
+    }
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/YdbSpliterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/YdbSpliterator.java
@@ -1,0 +1,81 @@
+package tech.ydb.yoj.repository.ydb.spliterator;
+
+import tech.ydb.yoj.repository.ydb.spliterator.queue.YojQueue;
+import tech.ydb.yoj.repository.ydb.spliterator.queue.YojSpliteratorQueue;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class YdbSpliterator<V> implements ClosableSpliterator<V> {
+    private final YojSpliteratorQueue<Iterator<V>> queue;
+    private final int flags;
+
+    private Iterator<V> valueIterator = Collections.emptyIterator();
+
+    private boolean closed = false;
+
+    public YdbSpliterator(YojQueue<Iterator<V>> queue, boolean isOrdered) {
+        this.queue = queue;
+        this.flags = (isOrdered ? ORDERED : 0) | NONNULL;
+    }
+
+    // Correct way to create stream with YdbSpliterator. onClose call is important for avoid supplier thread leak.
+    public Stream<V> createStream() {
+        return StreamSupport.stream(this, false).onClose(this::close);
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        queue.close();
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super V> action) {
+        if (closed) {
+            return false;
+        }
+
+        // queue could return empty iterator, we have to select one with elements
+        while (!valueIterator.hasNext()) {
+            valueIterator = queue.poll();
+            if (valueIterator == null) {
+                close();
+                return false;
+            }
+        }
+
+        V value = valueIterator.next();
+
+        action.accept(value);
+
+        return true;
+    }
+
+    @Override
+    public Spliterator<V> trySplit() {
+        return null;
+    }
+
+    @Override
+    public long estimateSize() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    public long getExactSizeIfKnown() {
+        return -1;
+    }
+
+    @Override
+    public int characteristics() {
+        return flags;
+    }
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/YdbSpliteratorQueueGrpcStreamAdapter.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/YdbSpliteratorQueueGrpcStreamAdapter.java
@@ -1,0 +1,63 @@
+package tech.ydb.yoj.repository.ydb.spliterator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tech.ydb.core.Status;
+import tech.ydb.yoj.repository.ydb.YdbOperations;
+import tech.ydb.yoj.repository.ydb.spliterator.queue.OfferDeadlineExceededException;
+import tech.ydb.yoj.repository.ydb.spliterator.queue.YojQueue;
+import tech.ydb.yoj.repository.ydb.spliterator.queue.YojSupplierQueue;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import static tech.ydb.yoj.repository.ydb.client.YdbValidator.validate;
+
+public final class YdbSpliteratorQueueGrpcStreamAdapter<V> {
+    private static final Logger log = LoggerFactory.getLogger(YdbSpliteratorQueueGrpcStreamAdapter.class);
+
+    private final String request;
+    private final YojSupplierQueue<V> queue;
+
+    public YdbSpliteratorQueueGrpcStreamAdapter(String request, YojQueue<V> queue) {
+        this.request = request;
+        this.queue = queue;
+    }
+
+    public void onNext(V values) {
+        if (!queue.offer(values)) {
+            // Need to abort supplier thread if stream is closed. onSupplierThreadComplete will exit immediately.
+            // ConsumerDoneException isn't handled because onSupplierThreadComplete will exit by this.closed.
+            throw ConsumerDoneException.INSTANCE;
+        }
+    }
+
+    // (supplier thread) Send knowledge to stream when data is over.
+    public void onSupplierThreadComplete(Status status, Throwable ex) {
+        var error = unwrapException(ex);
+        if (queue.isClosed() || error instanceof OfferDeadlineExceededException) {
+            log.error("Supplier thread was closed because consumer didn't poll an element of stream on timeout");
+            // If deadline exceeded happen, need to do nothing. Stream thread will exit at deadline by themself.
+            return;
+        }
+
+        queue.supplierDone(() -> {
+            if (error != null) {
+                throw YdbOperations.convertToRepositoryException(error);
+            }
+
+            validate(request, status.getCode(), status.toString());
+        });
+    }
+
+    private static Throwable unwrapException(Throwable ex) {
+        if (ex instanceof CompletionException || ex instanceof ExecutionException) {
+            return ex.getCause();
+        }
+        return ex;
+    }
+
+    private static class ConsumerDoneException extends RuntimeException {
+        public final static ConsumerDoneException INSTANCE = new ConsumerDoneException();
+    }
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/legacy/YdbLegacySpliterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/legacy/YdbLegacySpliterator.java
@@ -1,4 +1,4 @@
-package tech.ydb.yoj.repository.ydb;
+package tech.ydb.yoj.repository.ydb.spliterator.legacy;
 
 import tech.ydb.yoj.InternalApi;
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/OfferDeadlineExceededException.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/OfferDeadlineExceededException.java
@@ -1,0 +1,4 @@
+package tech.ydb.yoj.repository.ydb.spliterator.queue;
+
+public final class OfferDeadlineExceededException extends RuntimeException {
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojQueue.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojQueue.java
@@ -1,0 +1,4 @@
+package tech.ydb.yoj.repository.ydb.spliterator.queue;
+
+public interface YojQueue<V> extends YojSpliteratorQueue<V>, YojSupplierQueue<V> {
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojQueueImpl.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojQueueImpl.java
@@ -1,0 +1,135 @@
+package tech.ydb.yoj.repository.ydb.spliterator.queue;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import tech.ydb.yoj.repository.db.exception.DeadlineExceededException;
+import tech.ydb.yoj.repository.db.exception.QueryInterruptedException;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+
+public final class YojQueueImpl<V> implements YojQueue<V> {
+    private final BlockingQueue<Supplier<V>> queue;
+    private final long streamWorkDeadlineNanos;
+
+    private volatile boolean closed = false;
+
+    public static <V> YojQueueImpl<V> create(int maxQueueSize, Duration streamWorkTimeout) {
+        return new YojQueueImpl<>(
+                createQueue(maxQueueSize),
+                calculateDeadline(streamWorkTimeout)
+        );
+    }
+
+    private YojQueueImpl(BlockingQueue<Supplier<V>> queue, long streamWorkDeadlineNanos) {
+        this.queue = queue;
+        this.streamWorkDeadlineNanos = streamWorkDeadlineNanos;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    // (grpc thread) Send values to user-stream.
+    @Override
+    public boolean offer(V value) {
+        return offerValueSupplier(() -> value);
+    }
+
+    // (grpc thread) Send knowledge to user-stream when data is over (or error handled).
+    @Override
+    public void supplierDone(Runnable status) {
+        offerValueSupplier(() -> {
+            status.run();
+            return null;
+        });
+    }
+
+    // (user thread) Get values from grpc-stream. Could be called only from one thread because of volatile closed variable
+    @Nullable
+    @Override
+    public V poll() {
+        if (closed) {
+            return null;
+        }
+
+        Supplier<V> valueSupplier = pollValueSupplier();
+        if (valueSupplier == null) {
+            throw new DeadlineExceededException("Stream deadline exceeded on poll");
+        }
+
+        V value = valueSupplier.get();
+        if (value == null) {
+            close();
+        }
+
+        return value;
+    }
+
+    // (user thread) Could be called only from one thread with poll() because of volatile closed variable
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        queue.clear();
+    }
+
+    private boolean offerValueSupplier(Supplier<V> valueSupplier) throws OfferDeadlineExceededException {
+        if (closed) {
+            return false;
+        }
+
+        try {
+            if (!queue.offer(valueSupplier, calculateTimeout(), TimeUnit.NANOSECONDS)) {
+                throw new OfferDeadlineExceededException();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new QueryInterruptedException("Supplier thread interrupted", e);
+        }
+
+        return !closed;
+    }
+
+    @Nullable
+    private Supplier<V> pollValueSupplier() {
+        try {
+            return queue.poll(calculateTimeout(), TimeUnit.NANOSECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new QueryInterruptedException("Consumer thread interrupted", e);
+        }
+    }
+    
+    private long calculateTimeout() {
+        return TimeUnit.NANOSECONDS.toNanos(streamWorkDeadlineNanos - System.nanoTime());
+    }
+
+    private static <V> BlockingQueue<Supplier<V>> createQueue(int maxQueueSize) {
+        Preconditions.checkArgument(maxQueueSize >= 0, "maxQueueSize must be greater than 0");
+        if (maxQueueSize == 0) {
+            return new SynchronousQueue<>();
+        }
+        return new ArrayBlockingQueue<>(maxQueueSize);
+    }
+
+    private static long calculateDeadline(Duration streamWorkTimeout) {
+        return System.nanoTime() + TimeUnit.NANOSECONDS.toNanos(saturatedToNanos(streamWorkTimeout));
+    }
+
+    // copy-paste from com.google.common.util.concurrent.Uninterruptibles
+    private static long saturatedToNanos(Duration duration) {
+        try {
+            return duration.toNanos();
+        } catch (ArithmeticException ignore) {
+            return duration.isNegative() ? -9223372036854775808L : 9223372036854775807L;
+        }
+    }
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojSpliteratorQueue.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojSpliteratorQueue.java
@@ -1,0 +1,12 @@
+package tech.ydb.yoj.repository.ydb.spliterator.queue;
+
+import javax.annotation.Nullable;
+
+public interface YojSpliteratorQueue<V> {
+    // (user thread) Get values from grpc-stream. Could be called only from one thread because of volatile closed variable
+    @Nullable
+    V poll();
+
+    // (user thread) Could be called only from one thread with poll() because of volatile closed variable
+    void close();
+}

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojSupplierQueue.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/spliterator/queue/YojSupplierQueue.java
@@ -1,0 +1,11 @@
+package tech.ydb.yoj.repository.ydb.spliterator.queue;
+
+public interface YojSupplierQueue<V> {
+    // (grpc thread) Send values to user-stream.
+    boolean offer(V value) throws OfferDeadlineExceededException;
+
+    // (grpc thread) Send knowledge to user-stream when data is over (or error handled).
+    void supplierDone(Runnable status);
+
+    boolean isClosed();
+}

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
@@ -202,7 +202,9 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
 
         });
 
-        ReadTableParams<Project.Id> params = ReadTableParams.<Project.Id>builder().useNewSpliterator(true).build();
+        ReadTableParams<Project.Id> params = ReadTableParams.<Project.Id>builder()
+                .spliteratorType(ReadTableParams.SpliteratorType.LEGACY_SLOW)
+                .build();
         Stream<Project> readOnlyStream = db.readOnly().run(() -> db.projects().readTable(params));
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() ->

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/spliterator/legacy/YdbNewLegacySpliteratorTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/spliterator/legacy/YdbNewLegacySpliteratorTest.java
@@ -1,4 +1,4 @@
-package tech.ydb.yoj.repository.ydb;
+package tech.ydb.yoj.repository.ydb.spliterator.legacy;
 
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-public class YdbSpliteratorTest {
+public class YdbNewLegacySpliteratorTest {
     @SneakyThrows
     public static void doAfter(int millis, Runnable runnable) {
         Thread.sleep(millis);
@@ -88,7 +88,7 @@ public class YdbSpliteratorTest {
 
         private final AtomicInteger selectedValuesCount = new AtomicInteger();
 
-        private final YdbSpliterator<Integer> spliterator;
+        private final YdbNewLegacySpliterator<Integer> spliterator;
 
         private final List<Integer> bucketSizes = new ArrayList<>();
 
@@ -96,7 +96,7 @@ public class YdbSpliteratorTest {
         private Status status = Status.SUCCESS;
         private Throwable exception = null;
 
-        private ReadTableMock(YdbSpliterator<Integer> spliterator) {
+        private ReadTableMock(YdbNewLegacySpliterator<Integer> spliterator) {
             this.spliterator = spliterator;
         }
 
@@ -105,7 +105,7 @@ public class YdbSpliteratorTest {
         }
 
         public static ReadTableMock start(Duration timeout) {
-            YdbSpliterator<Integer> spliterator = new YdbSpliterator<>("stream", false, timeout);
+            YdbNewLegacySpliterator<Integer> spliterator = new YdbNewLegacySpliterator<>("stream", false, timeout);
 
             ReadTableMock mock = new ReadTableMock(spliterator);
             mock.run();
@@ -200,7 +200,7 @@ public class YdbSpliteratorTest {
     @Test
     @SneakyThrows
     public void endStreamWhenSupplerOfferValue() {
-        YdbSpliterator<Integer> spliterator = new YdbSpliterator<>("stream", false, Duration.ofMillis(500));
+        YdbNewLegacySpliterator<Integer> spliterator = new YdbNewLegacySpliterator<>("stream", false, Duration.ofMillis(500));
 
         spliterator.onNext(1);
 
@@ -209,7 +209,7 @@ public class YdbSpliteratorTest {
         thread.start();
 
         spliterator.onNext(2);
-        assertThatExceptionOfType(YdbSpliterator.ConsumerDoneException.class).isThrownBy(() ->
+        assertThatExceptionOfType(YdbNewLegacySpliterator.ConsumerDoneException.class).isThrownBy(() ->
                 spliterator.onNext(3)
         );
 

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/readtable/ReadTableParams.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/readtable/ReadTableParams.java
@@ -17,15 +17,8 @@ public class ReadTableParams<ID> {
     int rowLimit;
     @Builder.Default
     Duration timeout = Duration.ofSeconds(60);
-
-    /**
-     * Set this to {@code true} to use a {@code Spliterator} contract-conformant and less memory consuming implementation for the {@code Stream}
-     * returned by {@code readTable()}.
-     * <p>Note that using the new implementation currently has a negative performance impact, for more information refer to
-     * <a href="https://github.com/ydb-platform/yoj-project/issues/42">GitHub Issue #42</a>.
-     */
-    @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/42")
-    boolean useNewSpliterator;
+    @Builder.Default
+    SpliteratorType spliteratorType = SpliteratorType.LEGACY;
 
     int batchLimitBytes;
     int batchLimitRows;
@@ -47,5 +40,17 @@ public class ReadTableParams<ID> {
         public ReadTableParams.ReadTableParamsBuilder<ID> toKeyInclusive(ID toKey) {
             return toKey(toKey).toInclusive(true);
         }
+    }
+
+    public enum SpliteratorType {
+        LEGACY,
+        /**
+         * Set this to {@code true} to use a {@code Spliterator} contract-conformant and less memory consuming implementation for the {@code Stream}
+         * returned by {@code readTable()}.
+         * <p>Note that using the new implementation currently has a negative performance impact, for more information refer to
+         * <a href="https://github.com/ydb-platform/yoj-project/issues/42">GitHub Issue #42</a>.
+         */
+        LEGACY_SLOW,
+        EXPERIMENTAL,
     }
 }


### PR DESCRIPTION
The current implementation of the new spliterator was designed with minimal memory consumption in mind, as the ResultSet could be quite large. In YDB version 24.1, settings for response size for readTable have been introduced, so the current spliterator can be improved:

Idea:

* We read the ResultSet from the database and feed it into a Stream. While the Stream processes the ResultSet, we simultaneously read a new ResultSet so that by the time the first one is processed, the second one is already prepared.
* The Stream is almost lock-free. Locks taken only to fetch the ResultSet from the queue.
* The YDB-thread reads the ResultSet and places it in the queue. AFTER appending, if the queue is full, the YDB-thread sleeps until something takes the ResultSet from the queue. This ensures that at any given moment, no more than N + 1 ResultSets are in memory, where N is the size of the queue.
* If the element processing operation from the Stream is heavy, the process can be parallelized. YdbSpliteratorQueue supports fetching the ResultSet from multiple threads.
