### PR TITLE
#71: Support `java.util.UUID` natively (as `FieldValueType.UUID`)

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/FieldValueType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/FieldValueType.java
@@ -63,6 +63,10 @@ public enum FieldValueType {
      */
     INTERVAL,
     /**
+     * Universally Unique Identitifer (UUID). Java-side <strong>must</strong> be an instance of {@link java.util.UUID}.
+     */
+    UUID,
+    /**
      * Binary value: just a stream of uninterpreted bytes.
      * Java-side <strong>must</strong> be a {@code byte[]}.
      * <p>
@@ -167,11 +171,10 @@ public enum FieldValueType {
      * it allows comparing not strictly equal values in filter expressions, e.g., the String value of the ID
      * with the (flat) ID itself, which is a wrapper around String.
      *
-     * @param type Java object type. E.g., {@code String.class} for a String literal from the user
+     * @param type         Java object type. E.g., {@code String.class} for a String literal from the user
      * @param reflectField reflection information for the Schema field that the object of type {@code type}
-     * is supposed to be used with. E.g., reflection information for the (flat) ID field which the String
-     * literal is compared with.
-     *
+     *                     is supposed to be used with. E.g., reflection information for the (flat) ID field which the String
+     *                     literal is compared with.
      * @return database value type
      * @throws IllegalArgumentException if object of this type cannot be mapped to a database value
      */
@@ -185,10 +188,9 @@ public enum FieldValueType {
      * the {@link Column @Column} annotation value as well as custom value type information.
      * <p><strong>This method will most likely become package-private in YOJ 3.0.0! Please do not use it outside of YOJ code.</strong>
      *
-     * @param type Java object type
+     * @param type             Java object type
      * @param columnAnnotation {@code @Column} annotation for the field; {@code null} if absent
-     * @param cvt custom value type information; {@code null} if absent
-     *
+     * @param cvt              custom value type information; {@code null} if absent
      * @return database value type
      * @throws IllegalArgumentException if object of this type cannot be mapped to a database value
      */
@@ -210,6 +212,8 @@ public enum FieldValueType {
         } else if (type instanceof Class<?> clazz) {
             if (String.class.equals(clazz) || isCustomStringValueType(clazz)) {
                 return STRING;
+            } else if (java.util.UUID.class.equals(clazz)) {
+                return UUID;
             } else if (INTEGER_NUMERIC_TYPES.contains(clazz)) {
                 return INTEGER;
             } else if (REAL_NUMERIC_TYPES.contains(clazz)) {

--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/IllegalExpressionException.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/IllegalExpressionException.java
@@ -67,5 +67,11 @@ public abstract class IllegalExpressionException extends IllegalArgumentExceptio
                 super(field, "Type mismatch: cannot compare field \"%s\" with a date-time value"::formatted);
             }
         }
+
+        static final class UuidFieldExpected extends FieldTypeError {
+            UuidFieldExpected(String field) {
+                super(field, "Type mismatch: cannot compare field \"%s\" with an UUID value"::formatted);
+            }
+        }
     }
 }

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
@@ -77,14 +77,14 @@ final class Columns {
             value = CustomValueTypes.preconvert(field, value);
 
             return switch (field.getValueType()) {
-                case STRING -> value;
+                case STRING, BOOLEAN, INTEGER, REAL -> value;
+                case UUID -> CommonConverters.serializeUuidValue(value);
                 case ENUM -> DbTypeQualifier.ENUM_TO_STRING.equals(qualifier)
                         ? CommonConverters.serializeEnumToStringValue(serializedType, value)
                         : CommonConverters.serializeEnumValue(serializedType, value);
                 case OBJECT -> CommonConverters.serializeOpaqueObjectValue(serializedType, value);
                 case BINARY -> ((byte[]) value).clone();
                 case BYTE_ARRAY -> ((ByteArray) value).copy().getArray();
-                case BOOLEAN, INTEGER, REAL -> value;
                 // TODO: Unify Instant and Duration handling in InMemory and YDB Repository
                 case INTERVAL, TIMESTAMP -> value;
                 default -> throw new IllegalStateException("Don't know how to serialize field: " + field);
@@ -105,14 +105,14 @@ final class Columns {
             Preconditions.checkState(field.isSimple(), "Trying to deserialize a non-simple field: %s", field);
 
             var deserialized = switch (field.getValueType()) {
-                case STRING -> value;
+                case STRING, BOOLEAN, INTEGER, REAL -> value;
+                case UUID -> CommonConverters.deserializeUuidValue(value);
                 case ENUM -> DbTypeQualifier.ENUM_TO_STRING.equals(qualifier)
                         ? CommonConverters.deserializeEnumToStringValue(serializedType, value)
                         : CommonConverters.deserializeEnumValue(serializedType, value);
                 case OBJECT -> CommonConverters.deserializeOpaqueObjectValue(serializedType, value);
                 case BINARY -> ((byte[]) value).clone();
                 case BYTE_ARRAY -> ByteArray.copy((byte[]) value);
-                case BOOLEAN, INTEGER, REAL -> value;
                 // TODO: Unify Instant and Duration handling in InMemory and YDB Repository
                 case INTERVAL, TIMESTAMP -> value;
                 default -> throw new IllegalStateException("Don't know how to deserialize field: " + field);

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/entity/TestEntities.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/entity/TestEntities.java
@@ -1,7 +1,6 @@
 package tech.ydb.yoj.repository.test.entity;
 
 import lombok.NonNull;
-import tech.ydb.yoj.databind.FieldValueType;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.Repository;
 import tech.ydb.yoj.repository.test.sample.model.Book;
@@ -28,7 +27,6 @@ import tech.ydb.yoj.repository.test.sample.model.VersionedEntity;
 import tech.ydb.yoj.repository.test.sample.model.WithUnflattenableField;
 
 import java.util.List;
-import java.util.UUID;
 
 public final class TestEntities {
     private TestEntities() {
@@ -57,9 +55,6 @@ public final class TestEntities {
 
     @SuppressWarnings("unchecked")
     public static Repository init(@NonNull Repository repository) {
-        // Intentional Legacy registration. Used in e.g. UniqueEntity
-        FieldValueType.registerStringValueType(UUID.class);
-
         repository.createTablespace();
         ALL.forEach(entityClass -> repository.schema(entityClass).create());
 

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/yql/YqlTypeAllTypesLegacyMappingTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/yql/YqlTypeAllTypesLegacyMappingTest.java
@@ -26,9 +26,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.ydb.yoj.databind.FieldValueType.ENUM;
-import static tech.ydb.yoj.databind.FieldValueType.STRING;
-import static tech.ydb.yoj.databind.FieldValueType.TIMESTAMP;
 
 @RunWith(Parameterized.class)
 public class YqlTypeAllTypesLegacyMappingTest {
@@ -42,7 +39,7 @@ public class YqlTypeAllTypesLegacyMappingTest {
 
     @BeforeClass
     public static void setUp() {
-        YqlPrimitiveType.useLegacyMappingFor(STRING, ENUM, TIMESTAMP);
+        YqlPrimitiveType.useLegacyMappingFor(FieldValueType.values());
     }
 
     @Parameters

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/yql/YqlTypeAllTypesRecommendedMappingTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/yql/YqlTypeAllTypesRecommendedMappingTest.java
@@ -27,9 +27,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static tech.ydb.yoj.databind.FieldValueType.ENUM;
-import static tech.ydb.yoj.databind.FieldValueType.STRING;
-import static tech.ydb.yoj.databind.FieldValueType.TIMESTAMP;
 
 @RunWith(Parameterized.class)
 public class YqlTypeAllTypesRecommendedMappingTest {
@@ -43,12 +40,12 @@ public class YqlTypeAllTypesRecommendedMappingTest {
 
     @BeforeClass
     public static void setUp() {
-        YqlPrimitiveType.useRecommendedMappingFor(STRING, ENUM, TIMESTAMP);
+        YqlPrimitiveType.useRecommendedMappingFor(FieldValueType.values());
     }
 
     @AfterClass
     public static void tearDown() {
-        YqlPrimitiveType.useLegacyMappingFor(STRING, ENUM, TIMESTAMP);
+        YqlPrimitiveType.useLegacyMappingFor(FieldValueType.values());
     }
 
     @Parameters

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/EntityIdSchema.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/EntityIdSchema.java
@@ -24,6 +24,7 @@ import static tech.ydb.yoj.databind.FieldValueType.ENUM;
 import static tech.ydb.yoj.databind.FieldValueType.INTEGER;
 import static tech.ydb.yoj.databind.FieldValueType.STRING;
 import static tech.ydb.yoj.databind.FieldValueType.TIMESTAMP;
+import static tech.ydb.yoj.databind.FieldValueType.UUID;
 import static tech.ydb.yoj.databind.schema.naming.NamingStrategy.NAME_DELIMITER;
 
 public final class EntityIdSchema<ID extends Entity.Id<?>> extends Schema<ID> implements Comparator<ID> {
@@ -54,7 +55,7 @@ public final class EntityIdSchema<ID extends Entity.Id<?>> extends Schema<ID> im
     private static final Type ENTITY_TYPE_PARAMETER = Entity.Id.class.getTypeParameters()[0];
 
     private static final Set<FieldValueType> ALLOWED_ID_FIELD_TYPES = Set.of(
-            STRING, INTEGER, ENUM, BOOLEAN, TIMESTAMP, BYTE_ARRAY
+            STRING, INTEGER, ENUM, BOOLEAN, TIMESTAMP, UUID, BYTE_ARRAY
     );
 
     private <E extends Entity<E>> EntityIdSchema(EntitySchema<E> entitySchema) {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/common/CommonConverters.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/common/CommonConverters.java
@@ -9,6 +9,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Type;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -74,12 +75,10 @@ public final class CommonConverters {
         return (d, v) -> rawValueSetter.accept(d, serializeEnumToStringValue(type, v));
     }
 
-    public static String serializeEnumToStringValue(Type type, Object v) {
-        if (v instanceof Enum || v instanceof String) {
-            return v.toString();
-        } else {
-            throw new IllegalArgumentException("Enum value should be Enum or String but is " + type.getTypeName());
-        }
+    public static String serializeEnumToStringValue(Type ignored, Object v) {
+        Preconditions.checkArgument(v instanceof Enum || v instanceof String,
+                "Enum value must be a subclass of java.lang.Enum or a java.lang.String but is %s", v.getClass().getName());
+        return v.toString();
     }
 
     public static Object deserializeEnumToStringValue(Type type, Object src) {
@@ -95,6 +94,31 @@ public final class CommonConverters {
                 .collect(toUnmodifiableMap(Object::toString, e -> (Enum<?>) e));
 
         return v -> enumValues.get(((String) rawValueGetter.apply(v)));
+    }
+
+    public static <D> ThrowingSetter<D> uuidValueSetter(BiConsumer<D, Object> rawValueSetter) {
+        return (d, v) -> rawValueSetter.accept(d, serializeUuidValue(v));
+    }
+
+    // Intentional: Java UUID's compareTo() has a very unique (and very unexpected) ordering, treating two longs comprising the UUID as *signed*!
+    // So we always represent UUIDs in the database as text values, which has fairly consistent ordering in both Java and YDB.
+    // @see https://devblogs.microsoft.com/oldnewthing/20190913-00/?p=102859
+    public static String serializeUuidValue(Object v) {
+        Preconditions.checkArgument(v instanceof UUID || v instanceof String,
+                "Value must be an instance of java.util.UUID or a java.lang.String but is %s", v.getClass().getName());
+        return v.toString();
+    }
+
+    public static <S> ThrowingGetter<S> uuidValueGetter(Function<S, Object> rawValueGetter) {
+        return v -> deserializeUuidValue(rawValueGetter.apply(v));
+    }
+
+    public static Object deserializeUuidValue(Object v) {
+        if (v instanceof String str) {
+            return UUID.fromString(str);
+        } else {
+            throw new IllegalArgumentException("Value must be an instance of java.lang.String, got value of type " + v.getClass().getName());
+        }
     }
 
     public static <D> ThrowingSetter<D> opaqueObjectValueSetter(Type type, BiConsumer<D, Object> rawValueSetter) {


### PR DESCRIPTION
Note that this makes backward incompatible method signature changes in `FieldValue.Tuple` (which should **not** have been used in application code, anyway, but...)