### PR TITLE
Consider both  annotation - current field and parent

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/naming/AnnotationFirstNamingStrategy.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/naming/AnnotationFirstNamingStrategy.java
@@ -31,10 +31,19 @@ public class AnnotationFirstNamingStrategy implements NamingStrategy {
     private String getColumnName(Schema.JavaField field) {
         var annotation = field.getField().getColumn();
         if (annotation != null && !annotation.name().isEmpty()) {
-            return annotation.name();
+            var parentName = getParentAnnotationName(field);
+            return (parentName == null || parentName.isEmpty())
+                ? annotation.name()
+                : parentName + NAME_DELIMITER + annotation.name();
         }
 
         return getColumnNameFromField(field);
+    }
+
+    private String getParentAnnotationName(Schema.JavaField field) {
+        if (field.getParent() == null || field.getParent().getField() == null || field.getParent().getField().getColumn() == null)
+            return null;
+        return field.getParent().getField().getColumn().name();
     }
 
     protected String getColumnNameFromField(Schema.JavaField field) {

--- a/databind/src/test/java/tech/ydb/yoj/databind/schema/naming/AnnotationFirstNamingStrategyTest.java
+++ b/databind/src/test/java/tech/ydb/yoj/databind/schema/naming/AnnotationFirstNamingStrategyTest.java
@@ -37,7 +37,7 @@ public class AnnotationFirstNamingStrategyTest extends BaseNamingStrategyTestBas
     @Test
     public void testMixedEntityFieldNameTest() {
         verifyFieldNames(MixedEntity.class,
-                "column_name", "subEntity_boolValue", "sfe_timestamp", "id_stringValue", "int.val");
+                "column_name", "subEntity_boolValue", "sfe_timestamp", "id_stringValue", "int.val", "prefix_boolValue", "prefix_sfe_timestamp");
     }
 
     @Override

--- a/databind/src/test/java/tech/ydb/yoj/databind/schema/naming/MixedEntity.java
+++ b/databind/src/test/java/tech/ydb/yoj/databind/schema/naming/MixedEntity.java
@@ -12,6 +12,9 @@ public class MixedEntity {
 
     TestEntity.SubEntity subEntity;
 
+    @Column(name = "prefix")
+    TestEntity.SubEntity subEntityWithPrefix;
+
     @Value
     private static class Id {
         String stringValue;


### PR DESCRIPTION
According [documentation](https://github.com/ydb-platform/yoj-project/blob/897e1aecd3402fe027dd1186897c2ea8133dd010/databind/src/main/java/tech/ydb/yoj/databind/schema/Column.java#L34) of `Column.name`: `Each column will have the "BIG_SUBOBJ_FLAT" prefix`

But it doesn't work if child object has column annotation with specified `name`. In this case parent's `Column.name` is ignored. 
