### PR TITLE
Support for predefined consumers of CDC topics

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/Changefeed.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/Changefeed.java
@@ -44,7 +44,7 @@ public @interface Changefeed {
     /**
      * Initial consumers of the changefeed
      */
-    String[] consumers() default {};
+    Consumer[] consumers() default {};
 
     enum Mode {
         /**
@@ -75,5 +75,23 @@ public @interface Changefeed {
 
     enum Format {
         JSON
+    }
+
+    @interface Consumer {
+        String name();
+
+        Codec[] codecs() default {};
+
+        String readFrom() default "1970-01-01T00:00:00Z";
+
+        boolean important() default false;
+
+        enum Codec {
+            RAW,
+            GZIP,
+            LZOP,
+            ZSTD,
+            CUSTOM
+        }
     }
 }

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/Changefeed.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/Changefeed.java
@@ -41,6 +41,11 @@ public @interface Changefeed {
      */
     boolean initialScan() default false;
 
+    /**
+     * Initial consumers of the changefeed
+     */
+    String[] consumers() default {};
+
     enum Mode {
         /**
          * Only the key component of the modified row

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/Schema.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/Schema.java
@@ -252,7 +252,7 @@ public abstract class Schema<T> {
                 changefeed.virtualTimestamps(),
                 retentionPeriod,
                 changefeed.initialScan(),
-                List.of(changefeed.consumers())
+                Set.of(changefeed.consumers())
         );
     }
 
@@ -816,6 +816,6 @@ public abstract class Schema<T> {
         boolean initialScan;
 
         @NonNull
-        List<String> consumers;
+        Set<String> consumers;
     }
 }

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/Schema.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/Schema.java
@@ -251,7 +251,8 @@ public abstract class Schema<T> {
                 changefeed.format(),
                 changefeed.virtualTimestamps(),
                 retentionPeriod,
-                changefeed.initialScan()
+                changefeed.initialScan(),
+                List.of(changefeed.consumers())
         );
     }
 
@@ -813,5 +814,8 @@ public abstract class Schema<T> {
         Duration retentionPeriod;
 
         boolean initialScan;
+
+        @NonNull
+        List<String> consumers;
     }
 }

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/Schema.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/Schema.java
@@ -23,7 +23,9 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -245,6 +247,15 @@ public abstract class Schema<T> {
         var retentionPeriod = Duration.parse(changefeed.retentionPeriod());
         Preconditions.checkArgument(!(retentionPeriod.isNegative() || retentionPeriod.isZero()),
                 "RetentionPeriod value defined for %s must be positive", getType());
+        List<Changefeed.Consumer> consumers = Arrays.stream(changefeed.consumers())
+                .map(consumer -> new Changefeed.Consumer(
+                        consumer.name(),
+                        List.of(consumer.codecs()),
+                        Instant.parse(consumer.readFrom()),
+                        consumer.important()
+                ))
+                .toList();
+
         return new Changefeed(
                 changefeed.name(),
                 changefeed.mode(),
@@ -252,7 +263,7 @@ public abstract class Schema<T> {
                 changefeed.virtualTimestamps(),
                 retentionPeriod,
                 changefeed.initialScan(),
-                Set.of(changefeed.consumers())
+                consumers
         );
     }
 
@@ -816,6 +827,20 @@ public abstract class Schema<T> {
         boolean initialScan;
 
         @NonNull
-        Set<String> consumers;
+        List<Consumer> consumers;
+
+        @Value
+        public static class Consumer {
+            @NonNull
+            String name;
+
+            @NonNull
+            List<tech.ydb.yoj.databind.schema.Changefeed.Consumer.Codec> codecs;
+
+            @NonNull
+            Instant readFrom;
+
+            boolean important;
+        }
     }
 }

--- a/databind/src/test/java/tech/ydb/yoj/databind/schema/ChangefeedSchemaTest.java
+++ b/databind/src/test/java/tech/ydb/yoj/databind/schema/ChangefeedSchemaTest.java
@@ -25,6 +25,7 @@ public class ChangefeedSchemaTest {
         assertThat(entitySchema.getChangefeeds().get(0).getRetentionPeriod()).isEqualTo(Duration.ofHours(24));
         assertThat(entitySchema.getChangefeeds().get(0).isVirtualTimestamps()).isFalse();
         assertThat(entitySchema.getChangefeeds().get(0).isInitialScan()).isFalse();
+        assertThat(entitySchema.getChangefeeds().get(0).getConsumers()).isEmpty();
     }
 
     @Test
@@ -35,6 +36,19 @@ public class ChangefeedSchemaTest {
     @Test
     public void testConflictingChangefeedNameEntity() {
         assertThatThrownBy(() -> schemaOf(ConflictingChangefeedNameEntity.class));
+    }
+
+    @Test
+    public void testPredefinedConsumersChangefeedEntity() {
+        var entitySchema = schemaOf(PredefinedConsumersChangefeedEntity.class);
+
+        assertThat(entitySchema.getChangefeeds()).hasSize(1);
+        assertThat(entitySchema.getChangefeeds().get(0).getMode()).isEqualTo(Changefeed.Mode.NEW_IMAGE);
+        assertThat(entitySchema.getChangefeeds().get(0).getFormat()).isEqualTo(Changefeed.Format.JSON);
+        assertThat(entitySchema.getChangefeeds().get(0).getRetentionPeriod()).isEqualTo(Duration.ofHours(24));
+        assertThat(entitySchema.getChangefeeds().get(0).isVirtualTimestamps()).isFalse();
+        assertThat(entitySchema.getChangefeeds().get(0).isInitialScan()).isFalse();
+        assertThat(entitySchema.getChangefeeds().get(0).getConsumers()).containsExactly("consumer1", "consumer2");
     }
 
     private static <T> Schema<T> schemaOf(Class<T> entityType) {
@@ -71,6 +85,13 @@ public class ChangefeedSchemaTest {
     @Changefeed(name = "feed1")
     @Changefeed(name = "feed1")
     private static class ConflictingChangefeedNameEntity {
+        int field1;
+        int field2;
+    }
+
+    @Value
+    @Changefeed(name = "feed1", consumers = {"consumer1", "consumer2"})
+    private static class PredefinedConsumersChangefeedEntity {
         int field1;
         int field2;
     }

--- a/databind/src/test/java/tech/ydb/yoj/databind/schema/ChangefeedSchemaTest.java
+++ b/databind/src/test/java/tech/ydb/yoj/databind/schema/ChangefeedSchemaTest.java
@@ -48,7 +48,7 @@ public class ChangefeedSchemaTest {
         assertThat(entitySchema.getChangefeeds().get(0).getRetentionPeriod()).isEqualTo(Duration.ofHours(24));
         assertThat(entitySchema.getChangefeeds().get(0).isVirtualTimestamps()).isFalse();
         assertThat(entitySchema.getChangefeeds().get(0).isInitialScan()).isFalse();
-        assertThat(entitySchema.getChangefeeds().get(0).getConsumers()).containsExactly("consumer1", "consumer2");
+        assertThat(entitySchema.getChangefeeds().get(0).getConsumers()).containsExactlyInAnyOrder("consumer1", "consumer2");
     }
 
     private static <T> Schema<T> schemaOf(Class<T> entityType) {

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/ChangefeedEntity.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/ChangefeedEntity.java
@@ -16,7 +16,8 @@ import static tech.ydb.yoj.databind.schema.Changefeed.Mode.KEYS_ONLY;
         format = JSON,
         virtualTimestamps = true,
         retentionPeriod = "PT1H",
-        initialScan = false /* otherwise YDB is "overloaded" during YdbRepositoryIntegrationTest */
+        initialScan = false, /* otherwise YDB is "overloaded" during YdbRepositoryIntegrationTest */
+        consumers = {"test-consumer1", "test-consumer2"}
 )
 @Changefeed(name = "test-changefeed2")
 public class ChangefeedEntity implements Entity<ChangefeedEntity> {

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/ChangefeedEntity.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/ChangefeedEntity.java
@@ -17,7 +17,15 @@ import static tech.ydb.yoj.databind.schema.Changefeed.Mode.KEYS_ONLY;
         virtualTimestamps = true,
         retentionPeriod = "PT1H",
         initialScan = false, /* otherwise YDB is "overloaded" during YdbRepositoryIntegrationTest */
-        consumers = {"test-consumer1", "test-consumer2"}
+        consumers = {
+                @Changefeed.Consumer(name = "test-consumer1"),
+                @Changefeed.Consumer(
+                        name = "test-consumer2",
+                        readFrom = "2025-01-21T08:01:25+00:00",
+                        codecs = {Changefeed.Consumer.Codec.RAW},
+                        important = true
+                )
+        }
 )
 @Changefeed(name = "test-changefeed2")
 public class ChangefeedEntity implements Entity<ChangefeedEntity> {

--- a/repository-ydb-v2/BUILD
+++ b/repository-ydb-v2/BUILD
@@ -25,6 +25,7 @@ java_library(
         "@java_contribs_stable//:tech_ydb_ydb_sdk_core",
         "@java_contribs_stable//:tech_ydb_ydb_sdk_scheme",
         "@java_contribs_stable//:tech_ydb_ydb_sdk_table",
+        "@java_contribs_stable//:tech_ydb_ydb_sdk_topic",
     ],
 )
 
@@ -65,5 +66,6 @@ java_test_suite(
         "@java_contribs_stable//:tech_ydb_ydb_sdk_core",
         "@java_contribs_stable//:tech_ydb_ydb_sdk_scheme",
         "@java_contribs_stable//:tech_ydb_ydb_sdk_table",
+        "@java_contribs_stable//:tech_ydb_ydb_sdk_topic",
     ],
 )

--- a/repository-ydb-v2/pom.xml
+++ b/repository-ydb-v2/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>tech.ydb</groupId>
+            <artifactId>ydb-sdk-topic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tech.ydb</groupId>
             <artifactId>ydb-sdk-scheme</artifactId>
         </dependency>
         <dependency>

--- a/repository-ydb-v2/pom.xml
+++ b/repository-ydb-v2/pom.xml
@@ -41,6 +41,12 @@
         <dependency>
             <groupId>tech.ydb</groupId>
             <artifactId>ydb-sdk-topic</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>tech.ydb</groupId>

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
@@ -50,7 +50,9 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 import static lombok.AccessLevel.PRIVATE;
 import static tech.ydb.core.StatusCode.SCHEME_ERROR;
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
@@ -1,6 +1,5 @@
 package tech.ydb.yoj.repository.ydb.client;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import lombok.Getter;
 import lombok.NonNull;

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
@@ -28,6 +28,7 @@ import tech.ydb.proto.discovery.DiscoveryProtos;
 import tech.ydb.proto.discovery.v1.DiscoveryServiceGrpc;
 import tech.ydb.proto.scheme.v1.SchemeServiceGrpc;
 import tech.ydb.proto.table.v1.TableServiceGrpc;
+import tech.ydb.proto.topic.v1.TopicServiceGrpc;
 import tech.ydb.table.Session;
 import tech.ydb.table.SessionPoolStats;
 import tech.ydb.table.TableClient;
@@ -151,6 +152,7 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
                 .addService(new ProxyYdbTableService(channel))
                 .addService(proxyDiscoveryService)
                 .addService(new DelegateSchemeServiceImplBase(SchemeServiceGrpc.newStub(channel)))
+                .addService(new DelegateTopicServiceImplBase(TopicServiceGrpc.newStub(channel)))
                 .build();
         proxyServer.start();
         Runtime.getRuntime().addShutdownHook(new Thread(proxyServer::shutdown));
@@ -1021,6 +1023,12 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
     private static class DelegateSchemeServiceImplBase extends SchemeServiceGrpc.SchemeServiceImplBase {
         @Delegate
         final SchemeServiceGrpc.SchemeServiceStub schemeServiceStub;
+    }
+
+    @AllArgsConstructor
+    private static class DelegateTopicServiceImplBase extends TopicServiceGrpc.TopicServiceImplBase {
+        @Delegate
+        final TopicServiceGrpc.TopicServiceStub topicServiceStub;
     }
 
     private static class ProxyDiscoveryService extends DiscoveryServiceGrpc.DiscoveryServiceImplBase {


### PR DESCRIPTION
In this PR, we are adding an option to specify a list of consumers that will be created alongside the CDC topic during the initial bootstrap of the application.

A minor consideration is that TopicService/AlterTopic is not idempotent and will throw an exception if we specify already existing consumers in the addConsumer block. To address this behavior, we will perform a describe operation each time a table is attempted to be created.

These changes have been tested against local YDB (ydbplatform/local-ydb:latest version).