### PR TITLE
Fix balancing config access

### DIFF
--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbConfig.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbConfig.java
@@ -152,7 +152,7 @@ public class YdbConfig {
         /**
          * Use all available cluster nodes regardless datacenter locality
          */
-        static BalancingConfig useAllNodes() {
+        public static BalancingConfig useAllNodes() {
             return new BalancingConfig(Policy.USE_ALL_NODES, null);
         }
 
@@ -161,14 +161,14 @@ public class YdbConfig {
          *
          * @param preferableLocation a name of location
          */
-        static BalancingConfig usePreferableLocation(@NonNull String preferableLocation) {
+        public static BalancingConfig usePreferableLocation(@NonNull String preferableLocation) {
             return new BalancingConfig(Policy.USE_PREFERABLE_LOCATION, preferableLocation);
         }
 
         /**
          * Detecting of local DC by the latency measuring
          */
-        static BalancingConfig detectLocalDc() {
+        public static BalancingConfig detectLocalDc() {
             return new BalancingConfig(Policy.DETECT_LOCAL_DC, null);
         }
 


### PR DESCRIPTION
In PR #121, I made a stupid mistake with the new balancing configuration. Currently, the new options are not available due to incorrect visibility. Fixed in this pull request.