### PR TITLE
#135: Allow queries with no particular sort order

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/OrderExpression.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/OrderExpression.java
@@ -3,6 +3,7 @@ package tech.ydb.yoj.databind.expression;
 import com.google.common.base.Preconditions;
 import lombok.NonNull;
 import lombok.Value;
+import tech.ydb.yoj.ExperimentalApi;
 import tech.ydb.yoj.databind.schema.Schema;
 
 import java.util.List;
@@ -26,9 +27,56 @@ public class OrderExpression<T> {
                 .collect(toList()));
     }
 
+    /**
+     * Returns an {@code OrderExpression} that applies <em>no particular sort order</em> for the query results.
+     * The results will be returned in an implementation-defined order which is subject to change at any time,
+     * <em>potentially even giving a different ordering for repeated executions of the same query</em>.
+     * <p>This is different from the {@code OrderExpression} being {@code null} or not specified,
+     * which YOJ interprets as "order query results by entity ID ascending" to ensure maximum
+     * predictability of query results.
+     * <p><strong>BEWARE!</strong> For small queries that return results entirely from a single YDB table partition
+     * (<em>data shard</em>), the <em>no particular sort order</em> imposed by {@code OrderExpression.unordered()}
+     * on a real YDB database will <strong>most likely be the same</strong> as "order by entity ID ascending",
+     * but this will quickly and unpredictably change if the table and/or the result set grow bigger.
+     *
+     * @param schema schema to use
+     * @return an {@code OrderExpression} representing <em>no particular sort order</em>
+     *
+     * @param <U> schema type
+     */
+    @NonNull
+    @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/115")
+    public static <U> OrderExpression<U> unordered(@NonNull Schema<U> schema) {
+        return new OrderExpression<>(schema);
+    }
+
+    /**
+     * @return A fresh {@code Stream} of {@link SortKey sort keys} that this expression has.
+     * Will be empty if this expression represents an {@link #isUnordered() arbitrary sort order}.
+     */
     @NonNull
     public Stream<SortKey> keyStream() {
         return keys.stream();
+    }
+
+    /**
+     * @return {@code true} if this {@code OrderExpression} represents a well-defined sort order;
+     * {@code false} if the sort order is arbitrary
+     *
+     * @see #isUnordered()
+     */
+    @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/115")
+    public boolean isOrdered() {
+        return !keys.isEmpty();
+    }
+
+    /**
+     * @return {@code true} if this {@code OrderExpression} represents arbitrary sort order (whatever the database returns);
+     * {@code false} otherwise
+     */
+    @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/115")
+    public boolean isUnordered() {
+        return !isOrdered();
     }
 
     @Override
@@ -40,6 +88,11 @@ public class OrderExpression<T> {
         Preconditions.checkArgument(!keys.isEmpty(), "At least one sort key must be specified");
         this.schema = schema;
         this.keys = keys;
+    }
+
+    private OrderExpression(@NonNull Schema<T> schema) {
+        this.schema = schema;
+        this.keys = List.of();
     }
 
     @Value

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlListingQuery.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlListingQuery.java
@@ -165,7 +165,9 @@ public final class YqlListingQuery {
     }
 
     public static <T extends Entity<T>> YqlOrderBy toYqlOrderBy(@NonNull OrderExpression<T> orderBy) {
-        return YqlOrderBy.orderBy(orderBy.getKeys().stream().map(YqlListingQuery::toSortKey).collect(toList()));
+        return orderBy.isUnordered()
+                ? YqlOrderBy.unordered()
+                : YqlOrderBy.orderBy(orderBy.getKeys().stream().map(YqlListingQuery::toSortKey).collect(toList()));
     }
 
     private static YqlOrderBy.SortKey toSortKey(SortKey k) {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/EntityExpressions.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/EntityExpressions.java
@@ -1,9 +1,11 @@
 package tech.ydb.yoj.repository.db;
 
 import lombok.NonNull;
+import tech.ydb.yoj.ExperimentalApi;
 import tech.ydb.yoj.databind.expression.FilterBuilder;
 import tech.ydb.yoj.databind.expression.OrderBuilder;
 import tech.ydb.yoj.databind.expression.OrderExpression;
+import tech.ydb.yoj.databind.schema.Schema;
 
 import static tech.ydb.yoj.databind.expression.OrderExpression.SortOrder.ASCENDING;
 
@@ -17,6 +19,14 @@ public final class EntityExpressions {
 
     public static <T extends Entity<T>> OrderBuilder<T> newOrderBuilder(@NonNull Class<T> entityType) {
         return OrderBuilder.forSchema(schema(entityType));
+    }
+
+    /**
+     * @see OrderExpression#unordered(Schema)
+     */
+    @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/115")
+    public static <T extends Entity<T>> OrderExpression<T> unordered(@NonNull Class<T> entityType) {
+        return OrderExpression.unordered(schema(entityType));
     }
 
     private static <T extends Entity<T>> EntitySchema<T> schema(@NonNull Class<T> entityType) {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/TableQueryBuilder.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/TableQueryBuilder.java
@@ -3,10 +3,12 @@ package tech.ydb.yoj.repository.db;
 import com.google.common.base.Preconditions;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import tech.ydb.yoj.ExperimentalApi;
 import tech.ydb.yoj.databind.expression.FilterBuilder;
 import tech.ydb.yoj.databind.expression.FilterExpression;
 import tech.ydb.yoj.databind.expression.OrderBuilder;
 import tech.ydb.yoj.databind.expression.OrderExpression;
+import tech.ydb.yoj.databind.schema.Schema;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -195,6 +197,15 @@ public final class TableQueryBuilder<T extends Entity<T>> {
         } else {
             return null;
         }
+    }
+
+    /**
+     * @see OrderExpression#unordered(Schema)
+     */
+    @NonNull
+    @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/115")
+    public TableQueryBuilder<T> unordered() {
+        return orderBy(EntityExpressions.unordered(table.getType()));
     }
 
     @NonNull


### PR DESCRIPTION
Add experimental `unordered()` API to all common query paths 
(`OrderExpression`+`EntityExpressions`, `TableQueryBuilder`, `YqlOrderBy`).
The experimental API sets *no particular sort order* for the query results.

That is, the results will be returned in *an implementation-defined order*
which is subject to change at any time, *potentially even giving a different
ordering for repeated executions of the same query*.

This is different from the `OrderExpression` being `null` or `YqlOrderBy` missing,
because YOJ interprets these as "order query results by entity ID ascending" 
to ensure maximum predictability of query results.

There *might be* some modest performance gains from removing an implicit `ORDER BY`
clause from YOJ queries. The new experimental API allows users to take advantage
of these *potential* performance gains.