### PR TITLE
#131: FIX: Incorrect query results when same entity but different tables is used with find, save and insert

### DIFF
--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryTable.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryTable.java
@@ -166,11 +166,16 @@ public class InMemoryTable<T extends Entity<T>> implements Table<T> {
     }
 
     @Override
+    public TableDescriptor<T> getTableDescriptor() {
+        return tableDescriptor;
+    }
+
+    @Override
     public T find(Entity.Id<T> id) {
         if (id.isPartial()) {
             throw new IllegalArgumentException("Cannot use partial id in find method");
         }
-        return transaction.getTransactionLocal().firstLevelCache().get(id, __ -> {
+        return transaction.getTransactionLocal().firstLevelCache(tableDescriptor).get(id, __ -> {
             markKeyRead(id);
             T entity = transaction.doInTransaction("find(" + id + ")", tableDescriptor, shard -> shard.find(id));
             return postLoad(entity);
@@ -183,7 +188,7 @@ public class InMemoryTable<T extends Entity<T>> implements Table<T> {
             throw new IllegalArgumentException("Cannot use partial id in find method");
         }
 
-        FirstLevelCache cache = transaction.getTransactionLocal().firstLevelCache();
+        FirstLevelCache<T> cache = transaction.getTransactionLocal().firstLevelCache(tableDescriptor);
         if (cache.containsKey(id)) {
             return cache.peek(id)
                     .map(entity -> toView(viewType, schema, entity))
@@ -415,7 +420,7 @@ public class InMemoryTable<T extends Entity<T>> implements Table<T> {
         T t = tt.preSave();
         transaction.getWatcher().markRowRead(tableDescriptor, t.getId());
         transaction.doInWriteTransaction("insert(" + t + ")", tableDescriptor, shard -> shard.insert(t));
-        transaction.getTransactionLocal().firstLevelCache().put(t);
+        transaction.getTransactionLocal().firstLevelCache(tableDescriptor).put(t);
         transaction.getTransactionLocal().projectionCache().save(t);
         return t;
     }
@@ -424,7 +429,7 @@ public class InMemoryTable<T extends Entity<T>> implements Table<T> {
     public T save(T tt) {
         T t = tt.preSave();
         transaction.doInWriteTransaction("save(" + t + ")", tableDescriptor, shard -> shard.save(t));
-        transaction.getTransactionLocal().firstLevelCache().put(t);
+        transaction.getTransactionLocal().firstLevelCache(tableDescriptor).put(t);
         transaction.getTransactionLocal().projectionCache().save(t);
         return t;
     }
@@ -432,7 +437,7 @@ public class InMemoryTable<T extends Entity<T>> implements Table<T> {
     @Override
     public void delete(Entity.Id<T> id) {
         transaction.doInWriteTransaction("delete(" + id + ")", tableDescriptor, shard -> shard.delete(id));
-        transaction.getTransactionLocal().firstLevelCache().putEmpty(id);
+        transaction.getTransactionLocal().firstLevelCache(tableDescriptor).putEmpty(id);
         transaction.getTransactionLocal().projectionCache().delete(id);
     }
 
@@ -549,8 +554,8 @@ public class InMemoryTable<T extends Entity<T>> implements Table<T> {
     }
 
     @Override
-    public FirstLevelCache getFirstLevelCache() {
-        return transaction.getTransactionLocal().firstLevelCache();
+    public FirstLevelCache<T> getFirstLevelCache() {
+        return transaction.getTransactionLocal().firstLevelCache(tableDescriptor);
     }
 
     @Nullable
@@ -560,7 +565,7 @@ public class InMemoryTable<T extends Entity<T>> implements Table<T> {
             return null;
         }
         T t = entity.postLoad();
-        transaction.getTransactionLocal().firstLevelCache().put(t);
+        transaction.getTransactionLocal().firstLevelCache(tableDescriptor).put(t);
         transaction.getTransactionLocal().projectionCache().load(t);
         return t;
     }

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/UniqueProject.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/model/UniqueProject.java
@@ -4,6 +4,7 @@ import lombok.Value;
 import lombok.With;
 import tech.ydb.yoj.databind.schema.GlobalIndex;
 import tech.ydb.yoj.repository.db.Entity;
+import tech.ydb.yoj.repository.db.Table;
 
 @Value
 @GlobalIndex(name = "unique_name", fields = {"name"}, type = GlobalIndex.Type.UNIQUE)
@@ -17,6 +18,11 @@ public class UniqueProject implements Entity<UniqueProject> {
     @Value
     public static class Id implements Entity.Id<UniqueProject> {
         String value;
+    }
+
+    @Value
+    public static class NameView implements Table.View {
+        String name;
     }
 }
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/ByEntityYqlQueriesMerger.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/ByEntityYqlQueriesMerger.java
@@ -62,7 +62,7 @@ public class ByEntityYqlQueriesMerger implements YqlQueriesMerger {
         check(tableState.deleteAll == null && tableState.update == null,
                 "Modifications after delete_all or update aren't allowed");
         EntityState state;
-        Entity.Id id = getEntityId(query);
+        Entity.Id<?> id = getEntityId(query);
         if (tableState.entityStates.containsKey(id)) {
             state = tableState.entityStates.get(id);
             MergingState oldMergingState = state.getState();
@@ -121,9 +121,11 @@ public class ByEntityYqlQueriesMerger implements YqlQueriesMerger {
 
     private boolean needIgnoreQuery(EntityState entityState) {
         if (entityState.state == MergingState.UPSERT || entityState.state == MergingState.INSERT) {
-            Class<?> clazz = getEntityClass(entityState.query);
-            Entity.Id entityId = getEntityId(entityState.query);
-            RepositoryCache.Key key = new RepositoryCache.Key(clazz, entityId);
+            YqlStatement<?, ?, ?> srcStatement = convertQueryToYqlStatement(entityState.query);
+            Class<?> entityClass = srcStatement.getInSchemaType();
+            TableDescriptor<?> tableDescriptor = srcStatement.getTableDescriptor();
+            Entity.Id<?> entityId = getEntityId(entityState.query);
+            RepositoryCache.Key key = new RepositoryCache.Key(entityClass, tableDescriptor, entityId);
 
             if (entityState.state == MergingState.UPSERT) {
                 boolean newValueEqualsCached = cache.get(key)
@@ -160,41 +162,41 @@ public class ByEntityYqlQueriesMerger implements YqlQueriesMerger {
         return nextState;
     }
 
-    @SuppressWarnings("unchecked")
-    private static YdbRepository.Query convertInsertToUpsert(YdbRepository.Query<?> query) {
-        var type = getEntityClass(query);
-        var schema = EntitySchema.of(type);
-        var tableDescriptor = convertQueryToYqlStatement(query).getTableDescriptor();
-        var statement = new UpsertYqlStatement<>(tableDescriptor, schema);
-        return new YdbRepository.Query<>(statement, query.getValues().get(0));
+    private static <E extends Entity<E>> YdbRepository.Query<?> convertInsertToUpsert(YdbRepository.Query<?> query) {
+        YqlStatement<?, E, ?> srcStatement = convertQueryToYqlStatement(query);
+        EntitySchema<E> schema = srcStatement.getInSchema();
+        TableDescriptor<E> tableDescriptor = srcStatement.getTableDescriptor();
+
+        return new YdbRepository.Query<>(
+                new UpsertYqlStatement<>(tableDescriptor, schema),
+                query.getValues().get(0)
+        );
     }
 
-    @SuppressWarnings("unchecked")
-    private static YdbRepository.Query convertInsertToDelete(YdbRepository.Query<?> query) {
-        var type = getEntityClass(query);
-        var schema = EntitySchema.of(type);
-        var tableDescriptor = convertQueryToYqlStatement(query).getTableDescriptor();
-        var statement = new DeleteByIdStatement<>(tableDescriptor, schema);
-        return new YdbRepository.Query<>(statement, getEntityId(query));
+    private static <E extends Entity<E>> YdbRepository.Query<?> convertInsertToDelete(YdbRepository.Query<?> query) {
+        YqlStatement<?, E, ?> srcStatement = convertQueryToYqlStatement(query);
+        EntitySchema<E> schema = srcStatement.getInSchema();
+        TableDescriptor<E> tableDescriptor = srcStatement.getTableDescriptor();
+
+        return new YdbRepository.Query<>(
+                new DeleteByIdStatement<>(tableDescriptor, schema),
+                getEntityId(query)
+        );
     }
 
-    private static Entity.Id getEntityId(YdbRepository.Query<?> query) {
+    private static Entity.Id<?> getEntityId(YdbRepository.Query<?> query) {
         check(query.getValues().size() == 1, "Unsupported query");
 
         Object value = query.getValues().get(0);
         if (query.getStatement().getQueryType() == Statement.QueryType.DELETE) {
-            return (Entity.Id) value;
+            return (Entity.Id<?>) value;
         } else {
-            return ((Entity) value).getId();
+            return ((Entity<?>) value).getId();
         }
     }
 
-    private static Class getEntityClass(YdbRepository.Query query) {
-        return convertQueryToYqlStatement(query).getInSchemaType();
-    }
-
-    private static YqlStatement convertQueryToYqlStatement(YdbRepository.Query query) {
-        return (YqlStatement) query.getStatement();
+    private static <E extends Entity<E>> YqlStatement<?, E, ?> convertQueryToYqlStatement(YdbRepository.Query<?> query) {
+        return (YqlStatement<?, E, ?>) query.getStatement();
     }
 
     private static void check(boolean condition, String message) {
@@ -230,13 +232,13 @@ public class ByEntityYqlQueriesMerger implements YqlQueriesMerger {
 
     @With
     @Value
-    private class EntityState {
-        private YdbRepository.Query<?> query;
-        private MergingState state;
+    private static class EntityState {
+        YdbRepository.Query<?> query;
+        MergingState state;
     }
 
-    private class TableState {
-        private Map<Entity.Id, EntityState> entityStates = new HashMap<>();
+    private static class TableState {
+        private final Map<Entity.Id<?>, EntityState> entityStates = new HashMap<>();
         private YdbRepository.Query<?> deleteAll;
         private YdbRepository.Query<?> update;
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/FindYqlStatement.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/FindYqlStatement.java
@@ -36,7 +36,7 @@ public class FindYqlStatement<PARAMS, ENTITY extends Entity<ENTITY>, RESULT> ext
 
     @Override
     public List<RESULT> readFromCache(PARAMS params, RepositoryCache cache) {
-        RepositoryCache.Key key = new RepositoryCache.Key(resultSchema.getType(), params);
+        RepositoryCache.Key key = new RepositoryCache.Key(resultSchema.getType(), tableDescriptor, params);
         if (!cache.contains(key)) {
             return null;
         }
@@ -49,7 +49,7 @@ public class FindYqlStatement<PARAMS, ENTITY extends Entity<ENTITY>, RESULT> ext
 
     @Override
     public void storeToCache(PARAMS params, List<RESULT> result, RepositoryCache cache) {
-        RepositoryCache.Key key = new RepositoryCache.Key(resultSchema.getType(), params);
+        RepositoryCache.Key key = new RepositoryCache.Key(resultSchema.getType(), tableDescriptor, params);
         cache.put(key, result.stream().findFirst().orElse(null));
     }
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/Statement.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/Statement.java
@@ -72,24 +72,28 @@ public interface Statement<PARAMS, RESULT> {
     // First level cache
 
     /**
-     * Tries to read the query result from first-level cache.
+     * Tries to read the query result from statement cache.
      *
      * @param params parameter values.
      *               Might be {@code null} depending on the statement type, e.g. for DELETE statements.
-     * @param cache  first-level cache
-     * @return query result, if present in first-level cache; {@code null} otherwise
+     * @param cache  statement cache
+     * @return query result, if present in statement cache; {@code null} otherwise
+     *
+     * @see RepositoryCache
      */
     default List<RESULT> readFromCache(PARAMS params, RepositoryCache cache) {
         return null;
     }
 
     /**
-     * Writes the query result to first-level cache.
+     * Writes the query result to statement cache.
      *
      * @param params parameter values
      *               Might be {@code null} depending on the statement type, e.g. for DELETE statements.
      * @param result result to save; if {@code null}, nothing will be saved to cache
-     * @param cache  first-level cache
+     * @param cache  statement cache
+     *
+     * @see RepositoryCache
      */
     default void storeToCache(PARAMS params, List<RESULT> result, RepositoryCache cache) {
     }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/YqlStatement.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/YqlStatement.java
@@ -65,11 +65,10 @@ public abstract class YqlStatement<PARAMS, ENTITY extends Entity<ENTITY>, RESULT
             return;
         }
         for (Object o : result) {
-            if (o instanceof Entity) {
-                Entity<?> e = (Entity<?>) o;
-                cache.put(new RepositoryCache.Key(e.getClass(), e.getId()), e);
+            if (o instanceof Entity<?> e) {
+                cache.put(new RepositoryCache.Key(e.getClass(), tableDescriptor, e.getId()), e);
             } else {
-                // list should contains elements of the same type
+                // List contains elements of the same type, so if one of them is not suitable for caching, the others are not suitable as well
                 break;
             }
         }
@@ -171,6 +170,10 @@ public abstract class YqlStatement<PARAMS, ENTITY extends Entity<ENTITY>, RESULT
 
     public int hashCode() {
         return getQuery("").hashCode();
+    }
+
+    public EntitySchema<ENTITY> getInSchema() {
+        return schema;
     }
 
     public Class<ENTITY> getInSchemaType() {

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/table/YdbTable.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/table/YdbTable.java
@@ -67,9 +67,12 @@ import static tech.ydb.yoj.repository.db.EntityExpressions.defaultOrder;
 public class YdbTable<T extends Entity<T>> implements Table<T> {
     @Getter
     private final Class<T> type;
+
+    @Getter
+    private final TableDescriptor<T> tableDescriptor;
+
     private final QueryExecutor executor;
     private final EntitySchema<T> schema;
-    private final TableDescriptor<T> tableDescriptor;
 
     public YdbTable(Class<T> type, QueryExecutor executor) {
         this.type = type;
@@ -246,7 +249,7 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
         if (id.isPartial()) {
             throw new IllegalArgumentException("Cannot use partial id in find method");
         }
-        return executor.getTransactionLocal().firstLevelCache().get(id, __ -> {
+        return executor.getTransactionLocal().firstLevelCache(tableDescriptor).get(id, __ -> {
             var statement = new FindYqlStatement<>(tableDescriptor, schema, schema);
             List<T> res = postLoad(executor.execute(statement, id));
             return res.isEmpty() ? null : res.get(0);
@@ -343,7 +346,8 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
         List<T> found = postLoad(findUncached(ids, filter, orderBy, limit));
         if (!isPartialIdMode && ids.size() > found.size()) {
             Set<Id<T>> foundIds = found.stream().map(Entity::getId).collect(toSet());
-            Sets.difference(ids, foundIds).forEach(executor.getTransactionLocal().firstLevelCache()::putEmpty);
+            FirstLevelCache<T> cache = executor.getTransactionLocal().firstLevelCache(tableDescriptor);
+            Sets.difference(ids, foundIds).forEach(cache::putEmpty);
         }
         return found;
     }
@@ -463,6 +467,7 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
     }
 
     @Override
+    @Deprecated
     public void update(Entity.Id<T> id, Changeset changeset) {
         UpdateModel.ById<Id<T>> model = new UpdateModel.ById<>(id, changeset.toMap());
         executor.pendingExecute(new UpdateByIdStatement<>(tableDescriptor, schema, model), model);
@@ -472,7 +477,7 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
     public T insert(T t) {
         T entityToSave = t.preSave();
         executor.pendingExecute(new InsertYqlStatement<>(tableDescriptor, schema), entityToSave);
-        executor.getTransactionLocal().firstLevelCache().put(entityToSave);
+        executor.getTransactionLocal().firstLevelCache(tableDescriptor).put(entityToSave);
         executor.getTransactionLocal().projectionCache().save(entityToSave);
         return t;
     }
@@ -481,7 +486,7 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
     public T save(T t) {
         T entityToSave = t.preSave();
         executor.pendingExecute(new UpsertYqlStatement<>(tableDescriptor, schema), entityToSave);
-        executor.getTransactionLocal().firstLevelCache().put(entityToSave);
+        executor.getTransactionLocal().firstLevelCache(tableDescriptor).put(entityToSave);
         executor.getTransactionLocal().projectionCache().save(entityToSave);
         return t;
     }
@@ -489,7 +494,7 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
     @Override
     public void delete(Entity.Id<T> id) {
         executor.pendingExecute(new DeleteByIdStatement<>(tableDescriptor, schema), id);
-        executor.getTransactionLocal().firstLevelCache().putEmpty(id);
+        executor.getTransactionLocal().firstLevelCache(tableDescriptor).putEmpty(id);
         executor.getTransactionLocal().projectionCache().delete(id);
     }
 
@@ -515,8 +520,8 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
     }
 
     @Override
-    public FirstLevelCache getFirstLevelCache() {
-        return executor.getTransactionLocal().firstLevelCache();
+    public FirstLevelCache<T> getFirstLevelCache() {
+        return executor.getTransactionLocal().firstLevelCache(tableDescriptor);
     }
 
     @Override
@@ -526,7 +531,7 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
         if (e1 != e) {
             executor.getTransactionLocal().log().debug("    postLoad(%s) has diff", e1.getId());
         }
-        executor.getTransactionLocal().firstLevelCache().put(e1);
+        executor.getTransactionLocal().firstLevelCache(tableDescriptor).put(e1);
         executor.getTransactionLocal().projectionCache().load(e1);
         return e1;
     }
@@ -596,6 +601,15 @@ public class YdbTable<T extends Entity<T>> implements Table<T> {
         }
     }
 
+    /**
+     * @deprecated Blindly setting entity fields is not recommended. Use {@code Table.modifyIfPresent()} instead, unless you
+     * have specific requirements.
+     * <p>Blind updates disrupt query merging mechanism, so you typically won't able to run multiple blind update statements
+     * in the same transaction, or interleave them with upserts ({@code Table.save()}) and inserts.
+     * <p>Blind updates also do not update projections because they do not load the entity before performing the update;
+     * this can cause projections to be inconsistent with the main entity.
+     */
+    @Deprecated
     public <ID extends Id<T>> void updateIn(Collection<ID> ids, Changeset changeset) {
         var params = new UpdateInStatement.UpdateInStatementInput<>(ids, changeset.toMap());
 

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/merge/QueriesMergerTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/merge/QueriesMergerTest.java
@@ -41,7 +41,7 @@ public class QueriesMergerTest {
         QueriesMerger merger = QueriesMerger.create(cache);
 
         List<YdbRepository.Query<?>> queries = new ArrayList<>();
-        getProjects().forEach(p -> cache.put(new RepositoryCache.Key(p.getClass(), p.getId()), null));
+        getProjects().forEach(p -> cache.put(cacheKey(p), null));
         getProjects().forEach(p -> queries.add(insert(p)));
 
         merger.merge(queries);
@@ -177,6 +177,13 @@ public class QueriesMergerTest {
         EntitySchema<T> schema = EntitySchema.of((Class<T>) p.getClass());
         TableDescriptor<T> tableDescriptor = TableDescriptor.from(schema);
         return new YdbRepository.Query<>(new DeleteByIdStatement<>(tableDescriptor, schema), p.getId());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Entity<T>> RepositoryCache.Key cacheKey(T p) {
+        EntitySchema<T> schema = EntitySchema.of((Class<T>) p.getClass());
+        TableDescriptor<T> tableDescriptor = TableDescriptor.from(schema);
+        return new RepositoryCache.Key(p.getClass(), tableDescriptor, p.getId());
     }
 
     private ArrayList<Project> getProjects() {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/AbstractDelegatingTable.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/AbstractDelegatingTable.java
@@ -7,6 +7,7 @@ import tech.ydb.yoj.ExperimentalApi;
 import tech.ydb.yoj.databind.expression.FilterExpression;
 import tech.ydb.yoj.databind.expression.OrderExpression;
 import tech.ydb.yoj.repository.BaseDb;
+import tech.ydb.yoj.repository.db.cache.FirstLevelCache;
 import tech.ydb.yoj.repository.db.readtable.ReadTableParams;
 import tech.ydb.yoj.repository.db.statement.Changeset;
 
@@ -114,6 +115,16 @@ public abstract class AbstractDelegatingTable<T extends Entity<T>> implements Ta
     @Override
     public Class<T> getType() {
         return target.getType();
+    }
+
+    @Override
+    public FirstLevelCache<T> getFirstLevelCache() {
+        return target.getFirstLevelCache();
+    }
+
+    @Override
+    public TableDescriptor<T> getTableDescriptor() {
+        return target.getTableDescriptor();
     }
 
     @Override

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/Table.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/Table.java
@@ -38,6 +38,8 @@ public interface Table<T extends Entity<T>> {
 
     Class<T> getType();
 
+    TableDescriptor<T> getTableDescriptor();
+
     @CheckForNull
     T find(Entity.Id<T> id);
 
@@ -158,9 +160,7 @@ public interface Table<T extends Entity<T>> {
         return readTableIds(ReadTableParams.getDefault());
     }
 
-    default FirstLevelCache getFirstLevelCache() {
-        return null;
-    }
+    FirstLevelCache<T> getFirstLevelCache();
 
     @NonNull
     default <X extends Exception> T find(Entity.Id<T> id, Supplier<? extends X> throwIfAbsent) throws X {
@@ -347,6 +347,14 @@ public interface Table<T extends Entity<T>> {
         return new TableQueryBuilder<>(this);
     }
 
+    /**
+     * @deprecated Blindly setting entity fields is not recommended. Use {@code Table.modifyIfPresent()} instead, unless you
+     * have specific requirements.
+     * <p>Blind updates disrupt query merging mechanism, so you typically won't able to run multiple blind update statements
+     * in the same transaction, or interleave them with upserts ({@code Table.save()}) and inserts.
+     * <p>Blind updates also do not update projections because they do not load the entity before performing the update;
+     * this can cause projections to be inconsistent with the main entity.
+     */
     @Deprecated
     void update(Entity.Id<T> id, Changeset changeset);
 

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/EmptyFirstLevelCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/EmptyFirstLevelCache.java
@@ -3,37 +3,51 @@ package tech.ydb.yoj.repository.db.cache;
 import lombok.NonNull;
 import tech.ydb.yoj.repository.db.Entity;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Function;
 
-final class EmptyFirstLevelCache implements FirstLevelCache {
+/*package*/ final class EmptyFirstLevelCache<E extends Entity<E>> implements FirstLevelCache<E> {
+    private static final FirstLevelCache<?> INSTANCE = new EmptyFirstLevelCache<>();
+
+    @NonNull
+    @SuppressWarnings("unchecked")
+    public static <E extends Entity<E>> FirstLevelCache<E> instance() {
+        return (FirstLevelCache<E>) INSTANCE;
+    }
+
+    @Nullable
     @Override
-    public <E extends Entity<E>> E get(@NonNull Entity.Id<E> id, Function<Entity.Id<E>, E> loader) {
+    public E get(@NonNull Entity.Id<E> id, @NonNull Function<Entity.Id<E>, E> loader) {
         return loader.apply(id);
     }
 
+    @NonNull
     @Override
-    public <E extends Entity<E>> Optional<E> peek(@NonNull Entity.Id<E> id) {
+    public Optional<E> peek(@NonNull Entity.Id<E> id) {
         throw new NoSuchElementException();
     }
 
+    @NonNull
     @Override
-    public <E extends Entity<E>> List<E> snapshot(@NonNull Class<E> entityType) {
+    public List<E> snapshot() {
         return List.of();
     }
 
     @Override
-    public <E extends Entity<E>> void put(@NonNull E e) {
+    public void put(@NonNull E e) {
+        // NOOP
     }
 
     @Override
-    public <E extends Entity<E>> void putEmpty(@NonNull Entity.Id<E> id) {
+    public void putEmpty(@NonNull Entity.Id<E> id) {
+        // NOOP
     }
 
     @Override
-    public <E extends Entity<E>> boolean containsKey(Entity.@NonNull Id<E> id) {
+    public boolean containsKey(@NonNull Entity.Id<E> id) {
         return false;
     }
 }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/EmptyRepositoryCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/EmptyRepositoryCache.java
@@ -2,7 +2,7 @@ package tech.ydb.yoj.repository.db.cache;
 
 import java.util.Optional;
 
-class EmptyRepositoryCache implements RepositoryCache {
+/*package*/ class EmptyRepositoryCache implements RepositoryCache {
     static final RepositoryCache INSTANCE = new EmptyRepositoryCache();
 
     @Override

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/FirstLevelCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/FirstLevelCache.java
@@ -3,33 +3,86 @@ package tech.ydb.yoj.repository.db.cache;
 import lombok.NonNull;
 import tech.ydb.yoj.repository.db.Entity;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-
-public interface FirstLevelCache {
-    <E extends Entity<E>> E get(@NonNull Entity.Id<E> id, @NonNull Function<Entity.Id<E>, E> loader);
-
-    <E extends Entity<E>> Optional<E> peek(@NonNull Entity.Id<E> id);
+/**
+ * Caches the entities already loaded or saved in current transaction, to create the illusion of changes being applied immediately, even if the
+ * transaction runs in <em>delayed writes</em> mode which postpones all writes till commit time.
+ * <p>Unlike the {@link RepositoryCache} which saves the raw statement execution results, {@code FirstLevelCache} is more high-level in that it saves
+ * the {@code postLoad()}'ed entities; and also less general, in that it saves only entities, not views or any other data structures produced by
+ * database statements.
+ * <p>Each {@code TableDescriptor} used in the transaction will have its own {@code FirstLevelCache}.
+ *
+ * @param <E> entity type
+ */
+public interface FirstLevelCache<E extends Entity<E>> {
+    /**
+     * Loads the entity into the L1 cache.
+     *
+     * @param id              entity ID
+     * @param loader          loading function, returning {@code null} if the entity does not exist and a non-null entity (of type {@code E}) otherwise
+     * @return {@code null} if the entity does not exist; a non-null entity (of type {@code E}) otherwise
+     */
+    @Nullable
+    E get(@NonNull Entity.Id<E> id, @NonNull Function<Entity.Id<E>, E> loader);
 
     /**
-     * Returns a immutable copy of the entities of {@code entityType} type that are in the
-     * transaction L1 cache.
+     * Returns cache entry for the specified entity.
+     *
+     * @param id              entity ID
+     * @return cache entry (an empty {@code Optional} for nonexisting entity, a non-empty {@code Optional} for existing one)
      */
-    <E extends Entity<E>> List<E> snapshot(@NonNull Class<E> entityType);
+    @NonNull
+    Optional<E> peek(@NonNull Entity.Id<E> id);
 
-    <E extends Entity<E>> void put(@NonNull E e);
+    /**
+     * Returns a immutable copy of the entities of the specified table that are in the transaction L1 cache.
+     *
+     * @return unmodifiable <strong>snapshot</strong> (immutable copy) of the L1 cache
+     */
+    List<E> snapshot();
 
-    <E extends Entity<E>> void putEmpty(@NonNull Entity.Id<E> id);
+    /**
+     * Records the entity as existing.
+     *
+     * @param e               existing entity
+     * @see #putEmpty(Entity.Id)
+     */
+    void put(@NonNull E e);
 
-    <E extends Entity<E>> boolean containsKey(@NonNull Entity.Id<E> id);
+    /**
+     * Records the entity with the specified ID as being nonexistent.
+     *
+     * @param id              entity ID
+     * @see #put(Entity)
+     */
+    void putEmpty(@NonNull Entity.Id<E> id);
 
-    static FirstLevelCache empty() {
-        return new EmptyFirstLevelCache();
+    /**
+     * Checks whether there is an entry in the L1 cache for an entity with the specified ID (either for an entity existing, or for an entity
+     * being nonexistent).
+     *
+     * @param id              entity ID
+     * @return {@code true} if the specified entity exists in the cache; {@code false} otherwise
+     */
+    boolean containsKey(@NonNull Entity.Id<E> id);
+
+    /**
+     * @return L1 cache implementation that does not cache anything
+     * @param <E> entity type
+     */
+    static <E extends Entity<E>> FirstLevelCache<E> empty() {
+        return EmptyFirstLevelCache.instance();
     }
 
-    static FirstLevelCache create() {
-        return new FirstLevelCacheImpl();
+    /**
+     * @return standard L1 cache implementation
+     * @param <E> entity type
+     */
+    static <E extends Entity<E>> FirstLevelCache<E> create() {
+        return new FirstLevelCacheImpl<>();
     }
 }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/FirstLevelCacheProvider.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/FirstLevelCacheProvider.java
@@ -1,0 +1,23 @@
+package tech.ydb.yoj.repository.db.cache;
+
+import lombok.NonNull;
+import tech.ydb.yoj.repository.db.Entity;
+import tech.ydb.yoj.repository.db.TableDescriptor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/*package*/ final class FirstLevelCacheProvider {
+    private final Map<TableDescriptor<?>, FirstLevelCache<?>> caches = new HashMap<>();
+    private final Supplier<FirstLevelCache<?>> cacheCreator;
+
+    /*package*/ FirstLevelCacheProvider(@NonNull Supplier<FirstLevelCache<?>> cacheCreator) {
+        this.cacheCreator = cacheCreator;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <E extends Entity<E>> FirstLevelCache<E> getOrCreate(@NonNull TableDescriptor<E> descriptor) {
+        return (FirstLevelCache<E>) caches.computeIfAbsent(descriptor, __ -> cacheCreator.get());
+    }
+}

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/RepositoryCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/RepositoryCache.java
@@ -1,23 +1,117 @@
 package tech.ydb.yoj.repository.db.cache;
 
+import com.google.common.base.Preconditions;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import tech.ydb.yoj.DeprecationWarnings;
+import tech.ydb.yoj.repository.db.Entity;
+import tech.ydb.yoj.repository.db.EntitySchema;
+import tech.ydb.yoj.repository.db.TableDescriptor;
 
 import java.util.Optional;
 
+/**
+ * Caches DB statement execution results (via the {@code Statement.{readFromCache,storeToCache}} methods).
+ * This cache is per-transaction, but is more low-level than the {@code FirstLevelCache} because it caches
+ * raw statement results, e.g., entities <em>before</em> {@code postLoad()}.
+ * <p>It is primarily used to merge DB statements executed in the same transaction (for YDB implementation,
+ * see {@code QueriesMerger} in {@code yoj-repository-ydb-v2} module); but also to avoid recreating
+ * {@code View}s (which the {@link FirstLevelCache} does not cover).
+ * <p>For your own DB statements, you generally do <em>not</em> have to implement cache management:
+ * if the statement returns entities, you get the desired caching behavior automatically.
+ *
+ * @see FirstLevelCache
+ */
 public interface RepositoryCache {
+    /**
+     * @param key cache key
+     * @return {@code true} if the statement result cache has a recorded value for this key
+     */
     boolean contains(Key key);
 
+    /**
+     * @param key cache key
+     * @return cached value, if the cache {@link #contains(Key) contains this key} (can be empty!);
+     * {@code Optional.empty()} otherwise.
+     * <br>The return value is <strong>ambigious</strong>: you get {@code Optional.empty()} both if the cache
+     * {@link #contains(Key) contains the key} but has recorded "nothing found for the key", and if the cache
+     * does not contain the key at all.
+     * @see #contains(Key)
+     */
     Optional<Object> get(Key key);
 
+    /**
+     * Records a value in the statement cache.
+     *
+     * @param key   cache key
+     * @param value either value to save (an {@code Entity}, a {@code View}, or another type of statement result,
+     *              e.g. a wrapper for the {@code COUNT} statement);
+     *              or {@code null} if the statement has found nothing
+     */
     void put(Key key, Object value);
 
+    /**
+     * @return no-op statement cache implementation
+     */
     static RepositoryCache empty() {
         return EmptyRepositoryCache.INSTANCE;
     }
 
+    /**
+     * Cache key for a statement result.
+     */
     @Value
+    @RequiredArgsConstructor
     class Key {
-        Class<?> clazz;
+        /**
+         * Type of value stored by this key, typically an {@code Entity} or a {@code View}.
+         */
+        @NonNull
+        Class<?> valueType;
+
+        /**
+         * Descriptor for the table that this key corresponds to.
+         */
+        @NonNull
+        TableDescriptor<?> tableDescriptor;
+
+        /**
+         * Unique identifier of the value stored in {@code RepositoryCache}, typically an {@code Entity.Id}.
+         */
+        @NonNull
         Object id;
+
+        /**
+         * @deprecated This constructor will start throwing {@code UnsupportedOperationException} in YOJ 2.7.0
+         * and will be permanently removed in YOJ 3.0.0.
+         * <p>If your custom {@code YqlStatement}s make use of {@code readFromCache()} and {@code storeToCache()},
+         * please migrate them to use the new constructors: {@code RepositoryCache.Key(TableDescriptor, Entity.Id)}
+         * for caching entities themselves, and {@code RepositoryCache.Key(Class, TableDescriptor, Object)}
+         * for a more general version suitable for caching e.g. {@code View}s.
+         */
+        @Deprecated(forRemoval = true)
+        public Key(@NonNull Class<?> clazz, @NonNull Object id) {
+            DeprecationWarnings.warnOnce("tech.ydb.yoj.repository.db.cache.RepositoryCache.Key(Class<?>, Object)",
+                    "Please migrate to RepositoryCache.Key(Class<?>, TableDescriptor<?>, Object) constructor");
+
+            Preconditions.checkArgument(clazz.isAssignableFrom(Entity.class),
+                    "Deprecated RepositoryCache.Key(Class<?>, Object) constructor only entities, but got: %s", clazz);
+
+            this.valueType = clazz;
+
+            @SuppressWarnings({"unchecked", "rawtypes"}) EntitySchema<?> schema = EntitySchema.of((Class<Entity>) clazz);
+            this.tableDescriptor = TableDescriptor.from(schema);
+
+            this.id = id;
+        }
+
+        /**
+         * @deprecated Use the more clearly named {@code getValueType()} method.
+         */
+        @Deprecated(forRemoval = true)
+        public Class<?> getClazz() {
+            return valueType;
+        }
     }
 }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/TransactionLocal.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/TransactionLocal.java
@@ -1,6 +1,8 @@
 package tech.ydb.yoj.repository.db.cache;
 
 import lombok.NonNull;
+import tech.ydb.yoj.repository.db.Entity;
+import tech.ydb.yoj.repository.db.TableDescriptor;
 import tech.ydb.yoj.repository.db.Tx;
 import tech.ydb.yoj.repository.db.TxOptions;
 import tech.ydb.yoj.repository.db.projection.ProjectionCache;
@@ -14,12 +16,14 @@ import java.util.function.Supplier;
 public final class TransactionLocal {
     private final Map<Supplier<?>, Object> singletons = new IdentityHashMap<>();
 
-    private final Supplier<FirstLevelCache> firstLevelCacheSupplier;
+    private final Supplier<FirstLevelCacheProvider> cacheProviderSupplier;
     private final Supplier<ProjectionCache> projectionCacheSupplier;
     private final Supplier<TransactionLog> logSupplier;
 
     public TransactionLocal(@NonNull TxOptions options) {
-        this.firstLevelCacheSupplier = options.isFirstLevelCache() ? FirstLevelCache::create : FirstLevelCache::empty;
+        this.cacheProviderSupplier = () -> new FirstLevelCacheProvider(
+                options.isFirstLevelCache() ? FirstLevelCache::create : FirstLevelCache::empty
+        );
         this.projectionCacheSupplier = options.isMutable() ? RwProjectionCache::new : RoProjectionCache::new;
         this.logSupplier = () -> new TransactionLog(options.getLogLevel());
     }
@@ -33,14 +37,32 @@ public final class TransactionLocal {
         return (X) singletons.computeIfAbsent(supplier, Supplier::get);
     }
 
+    /**
+     * <strong>Warning:</strong> Unlike {@link #log()}, this method is not intended to be used by end-users,
+     * only by the YOJ implementation itself.
+     * <p>Also, projection support <em>might</em> be dropped or seriously reworked in YOJ 3.x, so please
+     * do not rely on this implementation detail.
+     */
     public ProjectionCache projectionCache() {
         return instance(projectionCacheSupplier);
     }
 
-    public FirstLevelCache firstLevelCache() {
-        return instance(firstLevelCacheSupplier);
+    /**
+     * <strong>Warning:</strong> Unlike {@link #log()}, this method is not intended to be used by end-users,
+     * only by the YOJ implementation itself.
+     *
+     * @param descriptor table descriptor
+     * @param <E>        entity type
+     * @return an instance of first-level cache for the specified table descriptor; will be the same
+     * for the duration of the transaction
+     */
+    public <E extends Entity<E>> FirstLevelCache<E> firstLevelCache(TableDescriptor<E> descriptor) {
+        return instance(cacheProviderSupplier).getOrCreate(descriptor);
     }
 
+    /**
+     * @return transaction log; its log entries are only written out if the transaction commits
+     */
     public TransactionLog log() {
         return instance(logSupplier);
     }

--- a/repository/src/test/java/tech/ydb/yoj/repository/db/cache/FirstLevelCacheTest.java
+++ b/repository/src/test/java/tech/ydb/yoj/repository/db/cache/FirstLevelCacheTest.java
@@ -1,36 +1,44 @@
 package tech.ydb.yoj.repository.db.cache;
 
-import lombok.Value;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import tech.ydb.yoj.repository.db.Entity;
+import tech.ydb.yoj.repository.db.EntitySchema;
+import tech.ydb.yoj.repository.db.RecordEntity;
+import tech.ydb.yoj.repository.db.TableDescriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class FirstLevelCacheTest {
-    private FirstLevelCache cache;
+    private FirstLevelCacheProvider cacheProvider;
+    private TableDescriptor<FooEntity> fooTableDescriptor;
+    private TableDescriptor<BarEntity> barTableDescriptor;
 
     @Before
     public void setUp() {
-        cache = FirstLevelCache.create();
+        cacheProvider = new FirstLevelCacheProvider(FirstLevelCache::create);
+        fooTableDescriptor = TableDescriptor.from(EntitySchema.of(FooEntity.class));
+        barTableDescriptor = TableDescriptor.from(EntitySchema.of(BarEntity.class));
     }
 
     @Test
-    public void testGetLoad() {
-        var id = FooEntity.Id.of(17);
+    public void getLoad() {
+        var id = new FooEntity.Id(17);
         var entity = new FooEntity(id);
 
+        var cache = cacheProvider.getOrCreate(fooTableDescriptor);
         var actual = cache.get(id, __ -> entity);
 
         assertThat(actual).isSameAs(entity);
     }
 
     @Test
-    public void testGetLoadNotFound() {
-        var id = FooEntity.Id.of(17);
+    public void getLoadNotFound() {
+        var id = new FooEntity.Id(17);
         boolean[] loaderCalled = {false};
 
+        var cache = cacheProvider.getOrCreate(fooTableDescriptor);
         var actual = cache.get(id, __ -> {
             loaderCalled[0] = true;
             return null;
@@ -41,15 +49,16 @@ public class FirstLevelCacheTest {
     }
 
     @Test
-    public void testGetFromCache() {
-        var id = FooEntity.Id.of(17);
+    public void getFromCache() {
+        var id = new FooEntity.Id(17);
         var entity = new FooEntity(id);
 
+        var cache = cacheProvider.getOrCreate(fooTableDescriptor);
         cache.get(id, __ -> entity);
 
         // Act
         var actual = cache.get(id, __ -> {
-            Assertions.fail("Loader MUST NOT be called");
+            fail("Loader MUST NOT be called");
             return null;
         });
 
@@ -58,16 +67,17 @@ public class FirstLevelCacheTest {
     }
 
     @Test
-    public void testPut() {
-        var id = FooEntity.Id.of(17);
+    public void put() {
+        var id = new FooEntity.Id(17);
         var entity = new FooEntity(id);
 
         // Act
+        var cache = cacheProvider.getOrCreate(fooTableDescriptor);
         cache.put(entity);
 
         // Verify
         var actual = cache.get(id, __ -> {
-            Assertions.fail("Loader MUST NOT be called");
+            fail("Loader MUST NOT be called");
             return null;
         });
 
@@ -75,13 +85,14 @@ public class FirstLevelCacheTest {
     }
 
     @Test
-    public void testPutEmpty() {
-        var id = FooEntity.Id.of(17);
+    public void putEmpty() {
+        var id = new FooEntity.Id(17);
         var entity = new FooEntity(id);
 
+        // Act
+        var cache = cacheProvider.getOrCreate(fooTableDescriptor);
         cache.put(entity);
 
-        // Act
         cache.putEmpty(id);
 
         // Verify
@@ -96,41 +107,42 @@ public class FirstLevelCacheTest {
     }
 
     @Test
-    public void testSnapshot() {
-        var entity1 = new FooEntity(FooEntity.Id.of(17));
-        var entity2 = new FooEntity(FooEntity.Id.of(23));
-        var entity3 = new BarEntity(BarEntity.Id.of("42"));
-        var id = FooEntity.Id.of(42);
+    public void snapshot() {
+        var entity1 = new FooEntity(new FooEntity.Id(17));
+        var entity2 = new FooEntity(new FooEntity.Id(23));
+        var entity3 = new BarEntity(new BarEntity.Id("42"));
+        var id = new FooEntity.Id(42);
 
-        cache.put(entity1);
-        cache.put(entity2);
-        cache.put(entity3);
-        cache.putEmpty(id);
+        var fooCache = cacheProvider.getOrCreate(fooTableDescriptor);
+        var barCache = cacheProvider.getOrCreate(barTableDescriptor);
 
-        // Act
-        var snapshot = cache.snapshot(FooEntity.class);
+        fooCache.put(entity1);
+        fooCache.put(entity2);
+        barCache.put(entity3);
+        fooCache.putEmpty(id);
 
-        // Verify
-        assertThat(snapshot).containsOnly(entity1, entity2);
+        var fooSnapshot = fooCache.snapshot();
+        var barSnapshot = barCache.snapshot();
+        assertThat(fooSnapshot).containsOnly(entity1, entity2);
+        assertThat(barSnapshot).containsOnly(entity3);
+
+        // FirstLevelCache.snapshot() is an immutable copy, so it should not see further changes to the cache
+        var entity4 = new FooEntity(new FooEntity.Id(99));
+        fooCache.put(entity4);
+        assertThat(fooSnapshot).containsOnly(entity1, entity2);
+
+        // Later snapshots should see the updated cache state
+        var fooSnapshot2 = fooCache.snapshot();
+        assertThat(fooSnapshot2).containsOnly(entity1, entity2, entity4);
     }
 
-    @Value
-    static class FooEntity implements Entity<FooEntity> {
-        Id id;
-
-        @Value(staticConstructor = "of")
-        static class Id implements Entity.Id<FooEntity> {
-            int value;
+    record FooEntity(FooEntity.Id id) implements RecordEntity<FooEntity> {
+        record Id(int value) implements Entity.Id<FooEntity> {
         }
     }
 
-    @Value
-    static class BarEntity implements Entity<BarEntity> {
-        Id id;
-
-        @Value(staticConstructor = "of")
-        static class Id implements Entity.Id<BarEntity> {
-            String value;
+    record BarEntity(BarEntity.Id id) implements RecordEntity<BarEntity> {
+        record Id(String value) implements Entity.Id<BarEntity> {
         }
     }
 }


### PR DESCRIPTION
Using `find([view], ID)`, `save()`, `insert()` on the same entity but with a different table name, will produce surprising results, essentially remembering which table was queried first and returning cached results from the first queried table for the whole transaction.

This PR fixes the underlying caching mechanisms (`FirstLevelCache` and `RepositoryCache`), augmenting their cache keys with `TableDescriptor`. This PR also improves the documentation on both these caches.