### PR TITLE
noticket: `@InternalApi` annotation for public members that are internal implementation details

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/DeprecationWarnings.java
+++ b/databind/src/main/java/tech/ydb/yoj/DeprecationWarnings.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+@InternalApi
 public final class DeprecationWarnings {
     private static final Logger log = LoggerFactory.getLogger(DeprecationWarnings.class);
     private static final Set<String> warnings = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/databind/src/main/java/tech/ydb/yoj/InternalApi.java
+++ b/databind/src/main/java/tech/ydb/yoj/InternalApi.java
@@ -1,0 +1,26 @@
+package tech.ydb.yoj;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+/**
+ * Annotates internal YOJ implementation details (classes, interfaces, methods, fields, constants, etc.) that need to be
+ * {@code public} to be used from different and/or multiple packages, but are not stable even across minor YOJ releases.
+ * <p>Non-{@code public} (e.g., package-private) classes, interfaces, methods, fields, constants etc. in YOJ are assumed
+ * to be internal implementation details regardless of the presence of an {@code &#64;InternalApi} annotation on them.
+ */
+@Target({TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, ANNOTATION_TYPE, PACKAGE, MODULE, RECORD_COMPONENT})
+@Retention(SOURCE)
+public @interface InternalApi {
+}

--- a/databind/src/main/java/tech/ydb/yoj/databind/CustomValueTypes.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/CustomValueTypes.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.reflect.TypeToken;
 import lombok.NonNull;
 import tech.ydb.yoj.ExperimentalApi;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.databind.converter.ValueConverter;
 import tech.ydb.yoj.databind.schema.Column;
 import tech.ydb.yoj.databind.schema.CustomConverterException;
@@ -18,6 +19,7 @@ import java.lang.reflect.Type;
 import static java.lang.reflect.Modifier.isAbstract;
 import static java.lang.reflect.Modifier.isStatic;
 
+@InternalApi
 @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/24")
 public final class CustomValueTypes {
     private CustomValueTypes() {
@@ -66,7 +68,6 @@ public final class CustomValueTypes {
     }
 
     @Nullable
-    @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/24")
     public static <J, C extends Comparable<? super C>> CustomValueTypeInfo<J, C> getCustomValueTypeInfo(
             @NonNull Type type, @Nullable Column columnAnnotation
     ) {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassComponent.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassComponent.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Type;
 /**
  * Represents a Kotlin data class component for the purposes of YOJ data-binding.
  */
-public final class KotlinDataClassComponent extends ReflectFieldBase {
+/*package*/ final class KotlinDataClassComponent extends ReflectFieldBase {
     private final KProperty1.Getter<?, ?> getter;
 
     public KotlinDataClassComponent(Reflector reflector, String name, KProperty1<?, ?> property) {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassType.java
@@ -18,7 +18,7 @@ import static java.util.stream.Collectors.toMap;
 /**
  * Represents a Kotlin data class for the purposes of YOJ data-binding.
  */
-public final class KotlinDataClassType<T> implements ReflectType<T> {
+/*package*/ final class KotlinDataClassType<T> implements ReflectType<T> {
     private final Class<T> type;
     private final Constructor<T> constructor;
     private final List<ReflectField> fields;

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassTypeFactory.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinDataClassTypeFactory.java
@@ -9,8 +9,8 @@ import java.lang.reflect.Method;
 
 import static java.util.Arrays.stream;
 
-public final class KotlinDataClassTypeFactory implements TypeFactory {
-    public static final TypeFactory instance = new KotlinDataClassTypeFactory();
+/*package*/ final class KotlinDataClassTypeFactory implements TypeFactory {
+    public static final TypeFactory INSTANCE = new KotlinDataClassTypeFactory();
 
     private static final int KIND_CLASS = 1;
 

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinReflectionDetector.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/KotlinReflectionDetector.java
@@ -3,7 +3,7 @@ package tech.ydb.yoj.databind.schema.reflect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class KotlinReflectionDetector {
+/*package*/ final class KotlinReflectionDetector {
     private static final Logger log = LoggerFactory.getLogger(KotlinReflectionDetector.class);
 
     private KotlinReflectionDetector() {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/PojoField.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/PojoField.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a field of a POJO class, hand-written or generated e.g. by Lombok.
  */
-public final class PojoField extends ReflectFieldBase {
+/*package*/ final class PojoField extends ReflectFieldBase {
     private final java.lang.reflect.Field delegate;
 
     public PojoField(@NonNull Reflector reflector, @NonNull java.lang.reflect.Field delegate) {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/PojoType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/PojoType.java
@@ -20,7 +20,7 @@ import static java.util.Comparator.comparing;
  * POJO with an all-args constructor. Currently allowed to have a constructor without {@link ConstructorProperties}
  * annotation.
  */
-public final class PojoType<T> implements ReflectType<T> {
+/*package*/ final class PojoType<T> implements ReflectType<T> {
     public static final StdReflector.TypeFactory FACTORY = new StdReflector.TypeFactory() {
         @Override
         public int priority() {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/RecordField.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/RecordField.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 /**
  * Represents a record class component for the purposes of YOJ data-binding.
  */
-public final class RecordField extends ReflectFieldBase {
+/*package*/ final class RecordField extends ReflectFieldBase {
     private final java.lang.reflect.Method accessor;
 
     public RecordField(@NonNull Reflector reflector, @NonNull java.lang.reflect.RecordComponent delegate) {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/RecordType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/RecordType.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * Represents a record class for the purposes of YOJ data-binding.
  */
-public final class RecordType<R extends Record> implements ReflectType<R> {
+/*package*/ final class RecordType<R extends Record> implements ReflectType<R> {
     public static final StdReflector.TypeFactory FACTORY = new StdReflector.TypeFactory() {
         @Override
         public int priority() {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/SimpleType.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/SimpleType.java
@@ -11,7 +11,7 @@ import java.util.List;
  *
  * @param <T> simple type
  */
-public final class SimpleType<T> implements ReflectType<T> {
+/*package*/ final class SimpleType<T> implements ReflectType<T> {
     public static final StdReflector.TypeFactory FACTORY = new StdReflector.TypeFactory() {
         @Override
         public int priority() {

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/StdReflector.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/StdReflector.java
@@ -26,7 +26,7 @@ import static java.util.Comparator.comparing;
 public final class StdReflector implements Reflector {
     public static final Reflector instance = new StdReflector(List.of(
             RecordType.FACTORY,
-            KotlinDataClassTypeFactory.instance,
+            KotlinDataClassTypeFactory.INSTANCE,
             PojoType.FACTORY,
             SimpleType.FACTORY
     ));

--- a/lombok.config
+++ b/lombok.config
@@ -8,6 +8,7 @@ lombok.log.jbosslog.flagUsage = error
 lombok.log.log4j.flagUsage = error
 lombok.log.log4j2.flagUsage = error
 lombok.log.xslf4j.flagUsage = error
+lombok.utilityClass.flagUsage = error
 lombok.addJavaxGeneratedAnnotation=true
 lombok.addLombokGeneratedAnnotation = true
 lombok.anyConstructor.addConstructorProperties=true

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/Columns.java
@@ -27,7 +27,7 @@ import static java.util.Collections.unmodifiableMap;
 import static org.eclipse.collections.impl.tuple.Tuples.pair;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-final class Columns {
+/*package*/ final class Columns {
     public static final Columns EMPTY = new Columns(Maps.immutable.empty());
 
     private final ImmutableMap<String, Object> map;

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryDataShard.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryDataShard.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-final class InMemoryDataShard<T extends Entity<T>> {
+/*package*/ final class InMemoryDataShard<T extends Entity<T>> {
     private final TableDescriptor<T> tableDescriptor;
     private final EntitySchema<T> schema;
     private final TreeMap<Entity.Id<T>, InMemoryEntityLine> entityLines;

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryEntityLine.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryEntityLine.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-final class InMemoryEntityLine {
+/*package*/ final class InMemoryEntityLine {
     private final List<Versioned> versions;
     private final Map<Long, Columns> uncommited = new HashMap<>();
 

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryStorage.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryStorage.java
@@ -8,7 +8,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-final class InMemoryStorage {
+/*package*/ final class InMemoryStorage {
     private final Map<TableDescriptor<?>, InMemoryDataShard<?>> shards;
     private final Map<Long, Set<TableDescriptor<?>>> uncommited = new HashMap<>();
 

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryTxLockWatcher.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryTxLockWatcher.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public final class InMemoryTxLockWatcher {
+/*package*/ final class InMemoryTxLockWatcher {
     public static final InMemoryTxLockWatcher NO_LOCKS = new InMemoryTxLockWatcher(Map.of(), Map.of());
 
     private final Map<TableDescriptor<?>, Set<Entity.Id<?>>> readRows;

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/ReadOnlyTxDataShard.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/ReadOnlyTxDataShard.java
@@ -6,7 +6,7 @@ import tech.ydb.yoj.repository.db.Table;
 import javax.annotation.Nullable;
 import java.util.List;
 
-interface ReadOnlyTxDataShard<T extends Entity<T>> {
+/*package*/ interface ReadOnlyTxDataShard<T extends Entity<T>> {
     @Nullable
     T find(Entity.Id<T> id);
 

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/TxDataShardImpl.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/TxDataShardImpl.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 @RequiredArgsConstructor
-final class TxDataShardImpl<T extends Entity<T>> implements ReadOnlyTxDataShard<T>, WriteTxDataShard<T> {
+/*package*/ final class TxDataShardImpl<T extends Entity<T>> implements ReadOnlyTxDataShard<T>, WriteTxDataShard<T> {
     private final InMemoryDataShard<T> shard;
     private final long txId;
     private final long version;

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/WriteTxDataShard.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/WriteTxDataShard.java
@@ -2,7 +2,7 @@ package tech.ydb.yoj.repository.test.inmemory;
 
 import tech.ydb.yoj.repository.db.Entity;
 
-interface WriteTxDataShard<T extends Entity<T>> {
+/*package*/ interface WriteTxDataShard<T extends Entity<T>> {
     void insert(T entity);
 
     void save(T entity);

--- a/repository-ydb-common/src/main/java/tech/ydb/yoj/repository/ydb/metrics/GaugeSupplierCollector.java
+++ b/repository-ydb-common/src/main/java/tech/ydb/yoj/repository/ydb/metrics/GaugeSupplierCollector.java
@@ -6,11 +6,13 @@ import io.prometheus.client.SimpleCollector;
 import lombok.experimental.Accessors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.ydb.yoj.InternalApi;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+@InternalApi
 public class GaugeSupplierCollector extends SimpleCollector<GaugeSupplierCollector.Child> implements Collector.Describable {
     private static final Logger log = LoggerFactory.getLogger(GaugeSupplierCollector.class);
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbLegacySpliterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbLegacySpliterator.java
@@ -1,5 +1,7 @@
 package tech.ydb.yoj.repository.ydb;
 
+import tech.ydb.yoj.InternalApi;
+
 import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -12,6 +14,7 @@ import java.util.stream.StreamSupport;
  * <a href="https://github.com/ydb-platform/yoj-project/issues/42">GitHub Issue #42</a>.
  */
 @Deprecated
+@InternalApi
 public class YdbLegacySpliterator<V> implements Spliterator<V> {
     private final int flags;
     private final Consumer<Consumer<? super V>> action;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbOperations.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbOperations.java
@@ -1,5 +1,6 @@
 package tech.ydb.yoj.repository.ydb;
 
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.exception.InternalRepositoryException;
 import tech.ydb.yoj.repository.db.exception.QueryInterruptedException;
 import tech.ydb.yoj.repository.db.exception.RepositoryException;
@@ -17,6 +18,7 @@ import java.util.concurrent.TimeoutException;
 import static tech.ydb.yoj.repository.ydb.client.YdbValidator.checkGrpcContextStatus;
 import static tech.ydb.yoj.util.lang.Interrupts.isThreadInterrupted;
 
+@InternalApi
 public final class YdbOperations {
     private YdbOperations() {
     }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
@@ -40,7 +40,6 @@ import tech.ydb.yoj.repository.db.TableDescriptor;
 import tech.ydb.yoj.repository.db.TxOptions;
 import tech.ydb.yoj.repository.db.bulk.BulkParams;
 import tech.ydb.yoj.repository.db.cache.RepositoryCache;
-import tech.ydb.yoj.repository.db.cache.RepositoryCacheImpl;
 import tech.ydb.yoj.repository.db.cache.TransactionLocal;
 import tech.ydb.yoj.repository.db.exception.IllegalTransactionIsolationLevelException;
 import tech.ydb.yoj.repository.db.exception.IllegalTransactionScanException;
@@ -107,7 +106,7 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
         this.repo = repo;
         this.options = options;
         this.transactionLocal = new TransactionLocal(options);
-        this.cache = options.isFirstLevelCache() ? new RepositoryCacheImpl() : RepositoryCache.empty();
+        this.cache = options.isFirstLevelCache() ? RepositoryCache.create() : RepositoryCache.empty();
     }
 
     private <V> YdbSpliterator<V> createSpliterator(String request, boolean isOrdered) {

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.ydb.core.Status;
 import tech.ydb.yoj.ExperimentalApi;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.exception.DeadlineExceededException;
 import tech.ydb.yoj.repository.db.exception.QueryInterruptedException;
 
@@ -33,6 +34,7 @@ import static tech.ydb.yoj.repository.ydb.client.YdbValidator.validate;
  * <p>Note that using the new implementation currently has a negative performance impact, for more information refer to
  * <a href="https://github.com/ydb-platform/yoj-project/issues/42">GitHub Issue #42</a>.
  */
+@InternalApi
 @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/42")
 public class YdbSpliterator<V> implements Spliterator<V> {
     private static final Logger log = LoggerFactory.getLogger(YdbSpliterator.class);

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/bulk/BulkMapper.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/bulk/BulkMapper.java
@@ -1,9 +1,11 @@
 package tech.ydb.yoj.repository.ydb.bulk;
 
 import tech.ydb.proto.ValueProtos;
+import tech.ydb.yoj.InternalApi;
 
 import java.util.Map;
 
+@InternalApi
 public interface BulkMapper<E> {
     String getTableName(String tableSpace);
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/bulk/BulkMapperImpl.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/bulk/BulkMapperImpl.java
@@ -2,6 +2,7 @@ package tech.ydb.yoj.repository.ydb.bulk;
 
 import com.google.protobuf.NullValue;
 import tech.ydb.proto.ValueProtos;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.EntitySchema;
@@ -11,6 +12,7 @@ import tech.ydb.yoj.repository.ydb.yql.YqlType;
 import java.util.HashMap;
 import java.util.Map;
 
+@InternalApi
 public final class BulkMapperImpl<E extends Entity<E>> implements BulkMapper<E> {
     private final TableDescriptor<E> tableDescriptor;
     private final EntitySchema<E> srcSchema;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/ResultSetConverter.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/ResultSetConverter.java
@@ -2,6 +2,7 @@ package tech.ydb.yoj.repository.ydb.client;
 
 import tech.ydb.proto.ValueProtos;
 import tech.ydb.table.result.ResultSetReader;
+import tech.ydb.yoj.InternalApi;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+@InternalApi
 public class ResultSetConverter {
     private final ResultSetReader resultSet;
     private List<ValueProtos.Column> columns = new ArrayList<>();

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbConverter.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbConverter.java
@@ -16,6 +16,7 @@ import tech.ydb.table.values.Value;
 import tech.ydb.table.values.VoidType;
 import tech.ydb.table.values.VoidValue;
 import tech.ydb.table.values.proto.ProtoValue;
+import tech.ydb.yoj.InternalApi;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.Map;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+@InternalApi
 public class YdbConverter {
     public static Value<?> toSDK(ValueProtos.TypedValue typedValue) {
         return toSDK(typedValue.getType(), typedValue.getValue());

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbIssue.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbIssue.java
@@ -2,9 +2,11 @@ package tech.ydb.yoj.repository.ydb.client;
 
 import lombok.RequiredArgsConstructor;
 import tech.ydb.core.Issue;
+import tech.ydb.yoj.InternalApi;
 
 import static lombok.AccessLevel.PRIVATE;
 
+@InternalApi
 @RequiredArgsConstructor(access = PRIVATE)
 public enum YdbIssue {
     DEFAULT_ERROR(0),

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbPaths.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbPaths.java
@@ -1,7 +1,9 @@
 package tech.ydb.yoj.repository.ydb.client;
 
 import com.google.common.base.Preconditions;
+import tech.ydb.yoj.InternalApi;
 
+@InternalApi
 public final class YdbPaths {
     private YdbPaths() {
     }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
@@ -31,6 +31,7 @@ import tech.ydb.topic.TopicClient;
 import tech.ydb.topic.description.Consumer;
 import tech.ydb.topic.description.TopicDescription;
 import tech.ydb.topic.settings.AlterTopicSettings;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.databind.schema.Changefeed.Consumer.Codec;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.repository.db.EntitySchema;
@@ -57,6 +58,7 @@ import static lombok.AccessLevel.PRIVATE;
 import static tech.ydb.core.StatusCode.SCHEME_ERROR;
 
 @Getter
+@InternalApi
 public class YdbSchemaOperations {
     private static final Logger log = LoggerFactory.getLogger(YdbSchemaOperations.class);
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbValidator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbValidator.java
@@ -8,6 +8,7 @@ import tech.ydb.core.Issue;
 import tech.ydb.core.StatusCode;
 import tech.ydb.table.query.DataQueryResult;
 import tech.ydb.table.result.ResultSetReader;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.exception.DeadlineExceededException;
 import tech.ydb.yoj.repository.db.exception.EntityAlreadyExistsException;
 import tech.ydb.yoj.repository.db.exception.OptimisticLockException;
@@ -27,6 +28,7 @@ import java.util.function.Function;
 
 import static lombok.AccessLevel.PRIVATE;
 
+@InternalApi
 public final class YdbValidator {
     private static final Logger log = LoggerFactory.getLogger(YdbValidator.class);
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/interceptors/CommonFullScanCallback.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/interceptors/CommonFullScanCallback.java
@@ -1,12 +1,10 @@
 package tech.ydb.yoj.repository.ydb.client.interceptors;
 
-import lombok.experimental.UtilityClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Consumer;
 
-@UtilityClass
 public final class CommonFullScanCallback {
     private static final Logger log = LoggerFactory.getLogger(CommonFullScanCallback.class);
 
@@ -15,7 +13,10 @@ public final class CommonFullScanCallback {
         throw new UnexpectedFullScanQueryError(query);
     };
 
-    public static class UnexpectedFullScanQueryError extends AssertionError {
+    private CommonFullScanCallback() {
+    }
+
+    public static final class UnexpectedFullScanQueryError extends AssertionError {
         public UnexpectedFullScanQueryError(String query) {
             super("Unexpected full scan query : " + query);
         }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/ByEntityYqlQueriesMerger.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/ByEntityYqlQueriesMerger.java
@@ -4,6 +4,7 @@ import lombok.Value;
 import lombok.With;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.EntitySchema;
 import tech.ydb.yoj.repository.db.TableDescriptor;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@InternalApi
 public class ByEntityYqlQueriesMerger implements YqlQueriesMerger {
     private static final Logger log = LoggerFactory.getLogger(ByEntityYqlQueriesMerger.class);
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/QueriesMerger.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/QueriesMerger.java
@@ -1,5 +1,6 @@
 package tech.ydb.yoj.repository.ydb.merge;
 
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.cache.RepositoryCache;
 import tech.ydb.yoj.repository.ydb.YdbRepository;
 import tech.ydb.yoj.repository.ydb.statement.YqlStatement;
@@ -12,6 +13,7 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 
+@InternalApi
 public class QueriesMerger {
     private final Supplier<YqlQueriesMerger> factory;
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/YqlQueriesMerger.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/merge/YqlQueriesMerger.java
@@ -1,9 +1,11 @@
 package tech.ydb.yoj.repository.ydb.merge;
 
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.ydb.YdbRepository;
 
 import java.util.List;
 
+@InternalApi
 public interface YqlQueriesMerger {
     void onNext(YdbRepository.Query<?> query);
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/readtable/EntityIdKeyMapper.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/readtable/EntityIdKeyMapper.java
@@ -2,6 +2,7 @@ package tech.ydb.yoj.repository.ydb.readtable;
 
 import com.google.protobuf.NullValue;
 import tech.ydb.proto.ValueProtos;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.EntityIdSchema;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@InternalApi
 public final class EntityIdKeyMapper<E extends Entity<E>, ID extends Entity.Id<E>, RESULT> implements ReadTableMapper<ID, RESULT> {
     private final TableDescriptor<E> tableDescriptor;
     private final EntitySchema<E> srcSchema;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/readtable/ReadTableMapper.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/readtable/ReadTableMapper.java
@@ -1,9 +1,11 @@
 package tech.ydb.yoj.repository.ydb.readtable;
 
 import tech.ydb.proto.ValueProtos;
+import tech.ydb.yoj.InternalApi;
 
 import java.util.List;
 
+@InternalApi
 public interface ReadTableMapper<ID, RESULT> {
     String getTableName(String tableSpace);
 

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/ResultSetReader.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/ResultSetReader.java
@@ -2,6 +2,7 @@ package tech.ydb.yoj.repository.ydb.statement;
 
 import lombok.NonNull;
 import tech.ydb.proto.ValueProtos;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.repository.db.exception.ConversionException;
 import tech.ydb.yoj.repository.ydb.yql.YqlType;
@@ -16,6 +17,7 @@ import static java.util.stream.Collectors.toMap;
 import static tech.ydb.yoj.repository.db.EntityIdSchema.isIdFieldName;
 import static tech.ydb.yoj.util.lang.BetterCollectors.toMapNullFriendly;
 
+@InternalApi
 public class ResultSetReader<RESULT> {
     private final Map<String, YqlType> fields;
     protected final Schema<RESULT> resultSchema;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/UpdateByIdStatement.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/UpdateByIdStatement.java
@@ -19,6 +19,15 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 import static java.util.stream.Stream.concat;
 
+/**
+ * @deprecated Blindly setting entity fields is not recommended. Use {@code Table.modifyIfPresent()} instead, unless you
+ * have specific requirements.
+ * <p>Blind updates disrupt query merging mechanism, so you typically won't able to run multiple blind update statements
+ * in the same transaction, or interleave them with upserts ({@code Table.save()}) and inserts.
+ * <p>Blind updates also do not update projections because they do not load the entity before performing the update;
+ * this can cause projections to be inconsistent with the main entity.
+ */
+@Deprecated
 public final class UpdateByIdStatement<ENTITY extends Entity<ENTITY>, ID extends Entity.Id<ENTITY>>
         extends YqlStatement<UpdateModel.ById<ID>, ENTITY, ENTITY> {
     private final Map<String, UpdateSetParam> setParams;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/UpdateModel.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/UpdateModel.java
@@ -11,6 +11,15 @@ import tech.ydb.yoj.repository.ydb.yql.YqlPredicate;
 import javax.annotation.Nullable;
 import java.util.Map;
 
+/**
+ * @deprecated Blindly setting entity fields is not recommended. Use {@code Table.modifyIfPresent()} instead, unless you
+ * have specific requirements.
+ * <p>Blind updates disrupt query merging mechanism, so you typically won't able to run multiple blind update statements
+ * in the same transaction, or interleave them with upserts ({@code Table.save()}) and inserts.
+ * <p>Blind updates also do not update projections because they do not load the entity before performing the update;
+ * this can cause projections to be inconsistent with the main entity.
+ */
+@Deprecated
 @Getter
 @ToString
 public abstract class UpdateModel {
@@ -43,6 +52,10 @@ public abstract class UpdateModel {
         return newValues.get(fieldPath);
     }
 
+    /**
+     * @deprecated {@link UpdateModel} is deprecated
+     */
+    @Deprecated
     @Getter
     public static final class ByPredicate extends UpdateModel {
         private final YqlPredicate predicate;
@@ -53,6 +66,10 @@ public abstract class UpdateModel {
         }
     }
 
+    /**
+     * @deprecated {@link UpdateModel} is deprecated
+     */
+    @Deprecated
     @Getter
     public static final class ById<ID extends Id<?>> extends UpdateModel {
         private final ID id;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/UpdateSetParam.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/UpdateSetParam.java
@@ -8,6 +8,15 @@ import tech.ydb.yoj.repository.ydb.yql.YqlType;
 
 import java.util.stream.Stream;
 
+/**
+ * @deprecated Blindly setting entity fields is not recommended. Use {@code Table.modifyIfPresent()} instead, unless you
+ * have specific requirements.
+ * <p>Blind updates disrupt query merging mechanism, so you typically won't able to run multiple blind update statements
+ * in the same transaction, or interleave them with upserts ({@code Table.save()}) and inserts.
+ * <p>Blind updates also do not update projections because they do not load the entity before performing the update;
+ * this can cause projections to be inconsistent with the main entity.
+ */
+@Deprecated
 @Getter
 public final class UpdateSetParam extends PredicateStatement.Param {
     private static final String PREFIX = "set_";

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/merge/QueriesMergerTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/merge/QueriesMergerTest.java
@@ -6,13 +6,11 @@ import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.EntitySchema;
 import tech.ydb.yoj.repository.db.TableDescriptor;
 import tech.ydb.yoj.repository.db.cache.RepositoryCache;
-import tech.ydb.yoj.repository.db.cache.RepositoryCacheImpl;
 import tech.ydb.yoj.repository.test.sample.model.Primitive;
 import tech.ydb.yoj.repository.test.sample.model.Project;
 import tech.ydb.yoj.repository.ydb.YdbRepository;
 import tech.ydb.yoj.repository.ydb.statement.DeleteAllStatement;
 import tech.ydb.yoj.repository.ydb.statement.DeleteByIdStatement;
-import tech.ydb.yoj.repository.ydb.statement.FindYqlStatement;
 import tech.ydb.yoj.repository.ydb.statement.InsertYqlStatement;
 import tech.ydb.yoj.repository.ydb.statement.Statement;
 import tech.ydb.yoj.repository.ydb.statement.UpsertYqlStatement;
@@ -37,7 +35,7 @@ public class QueriesMergerTest {
 
     @Test
     public void mergeFindInsertQueries() {
-        RepositoryCacheImpl cache = new RepositoryCacheImpl();
+        RepositoryCache cache = RepositoryCache.create();
         QueriesMerger merger = QueriesMerger.create(cache);
 
         List<YdbRepository.Query<?>> queries = new ArrayList<>();
@@ -118,7 +116,6 @@ public class QueriesMergerTest {
         Assertions.assertThat(result.get(0).getStatement().getQueryType()).isEqualTo(Statement.QueryType.INSERT);
         assertThat(result.get(0).getValues()).isEqualTo(Collections.singletonList(p));
         Assertions.assertThat(result.get(1).getStatement().getQueryType()).isEqualTo(Statement.QueryType.DELETE);
-        //noinspection unchecked
         assertThat(result.get(1).getValues()).hasSize(3);
     }
 
@@ -141,7 +138,7 @@ public class QueriesMergerTest {
     }
 
     private QueriesMerger createMerger() {
-        return QueriesMerger.create(new RepositoryCacheImpl());
+        return QueriesMerger.create(RepositoryCache.create());
     }
 
     private <T extends Entity<T>> YdbRepository.Query<?> deleteAll(Class<T> clazz) {
@@ -162,14 +159,6 @@ public class QueriesMergerTest {
         EntitySchema<T> schema = EntitySchema.of((Class<T>) p.getClass());
         TableDescriptor<T> tableDescriptor = TableDescriptor.from(schema);
         return new YdbRepository.Query<>(new InsertYqlStatement<>(tableDescriptor, schema), p);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T extends Entity<T>> YdbRepository.Query<?> find(T p) {
-        EntitySchema<T> schema = EntitySchema.of((Class<T>) p.getClass());
-        TableDescriptor<T> tableDescriptor = TableDescriptor.from(schema);
-        var statement = new FindYqlStatement<>(tableDescriptor, schema, schema);
-        return new YdbRepository.Query<>(statement, p.getId());
     }
 
     @SuppressWarnings("unchecked")

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/Table.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/Table.java
@@ -2,6 +2,7 @@ package tech.ydb.yoj.repository.db;
 
 import com.google.common.collect.Sets;
 import lombok.NonNull;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.databind.expression.FilterExpression;
 import tech.ydb.yoj.databind.expression.OrderExpression;
 import tech.ydb.yoj.repository.db.bulk.BulkParams;
@@ -160,6 +161,7 @@ public interface Table<T extends Entity<T>> {
         return readTableIds(ReadTableParams.getDefault());
     }
 
+    @InternalApi
     FirstLevelCache<T> getFirstLevelCache();
 
     @NonNull
@@ -322,6 +324,7 @@ public interface Table<T extends Entity<T>> {
         throw new UnsupportedOperationException();
     }
 
+    @InternalApi
     default TableQueryBuilder<T> toQueryBuilder(ListRequest<T> request) {
         return query()
                 .index(request.getIndex())
@@ -331,10 +334,12 @@ public interface Table<T extends Entity<T>> {
                 .limit(request.getPageSize() + 1);
     }
 
+    @InternalApi
     default List<T> postLoad(List<T> list) {
         return list.stream().map(this::postLoad).collect(Collectors.toList());
     }
 
+    @InternalApi
     default T postLoad(T e) {
         return e.postLoad();
     }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/FirstLevelCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/FirstLevelCache.java
@@ -1,6 +1,7 @@
 package tech.ydb.yoj.repository.db.cache;
 
 import lombok.NonNull;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 
 import javax.annotation.Nullable;
@@ -18,6 +19,7 @@ import java.util.function.Function;
  *
  * @param <E> entity type
  */
+@InternalApi
 public interface FirstLevelCache<E extends Entity<E>> {
     /**
      * Loads the entity into the L1 cache.

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/RepositoryCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/RepositoryCache.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import tech.ydb.yoj.DeprecationWarnings;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.EntitySchema;
 import tech.ydb.yoj.repository.db.TableDescriptor;
@@ -23,6 +24,7 @@ import java.util.Optional;
  *
  * @see FirstLevelCache
  */
+@InternalApi
 public interface RepositoryCache {
     /**
      * @param key cache key
@@ -56,6 +58,13 @@ public interface RepositoryCache {
      */
     static RepositoryCache empty() {
         return EmptyRepositoryCache.INSTANCE;
+    }
+
+    /**
+     * @return an instance of standard cache implementation
+     */
+    static RepositoryCache create() {
+        return new RepositoryCacheImpl();
     }
 
     /**

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/RepositoryCacheImpl.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/RepositoryCacheImpl.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-public class RepositoryCacheImpl implements RepositoryCache {
+/*package*/ class RepositoryCacheImpl implements RepositoryCache {
     private final Map<Key, Optional<Object>> cache = new HashMap<>();
 
     @Override

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/cache/TransactionLocal.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/cache/TransactionLocal.java
@@ -1,6 +1,7 @@
 package tech.ydb.yoj.repository.db.cache;
 
 import lombok.NonNull;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.TableDescriptor;
 import tech.ydb.yoj.repository.db.Tx;
@@ -32,6 +33,11 @@ public final class TransactionLocal {
         return Tx.Current.get().getRepositoryTransaction().getTransactionLocal();
     }
 
+    /**
+     * @param supplier supplier of transaction-local state
+     * @return gets or creates (using the {@code supplier}) transaction-local state
+     * @param <X> type of transaction-local state
+     */
     @SuppressWarnings("unchecked")
     public <X> X instance(@NonNull Supplier<X> supplier) {
         return (X) singletons.computeIfAbsent(supplier, Supplier::get);
@@ -43,6 +49,7 @@ public final class TransactionLocal {
      * <p>Also, projection support <em>might</em> be dropped or seriously reworked in YOJ 3.x, so please
      * do not rely on this implementation detail.
      */
+    @InternalApi
     public ProjectionCache projectionCache() {
         return instance(projectionCacheSupplier);
     }
@@ -56,6 +63,7 @@ public final class TransactionLocal {
      * @return an instance of first-level cache for the specified table descriptor; will be the same
      * for the duration of the transaction
      */
+    @InternalApi
     public <E extends Entity<E>> FirstLevelCache<E> firstLevelCache(TableDescriptor<E> descriptor) {
         return instance(cacheProviderSupplier).getOrCreate(descriptor);
     }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/common/CommonConverters.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/common/CommonConverters.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.ydb.yoj.InternalApi;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Type;
@@ -17,6 +18,7 @@ import java.util.stream.Stream;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
+@InternalApi
 @ParametersAreNonnullByDefault
 public final class CommonConverters {
     private static final Logger log = LoggerFactory.getLogger(CommonConverters.class);

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/projection/ProjectionCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/projection/ProjectionCache.java
@@ -1,9 +1,11 @@
 package tech.ydb.yoj.repository.db.projection;
 
 
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.RepositoryTransaction;
 
+@InternalApi
 public interface ProjectionCache {
     void load(Entity<?> entity);
 

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/projection/RoProjectionCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/projection/RoProjectionCache.java
@@ -1,8 +1,10 @@
 package tech.ydb.yoj.repository.db.projection;
 
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.RepositoryTransaction;
 
+@InternalApi
 public class RoProjectionCache implements ProjectionCache {
     @Override
     public void load(Entity<?> entity) {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/projection/RwProjectionCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/projection/RwProjectionCache.java
@@ -2,6 +2,7 @@ package tech.ydb.yoj.repository.db.projection;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.RepositoryTransaction;
 
@@ -11,6 +12,7 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 
+@InternalApi
 public class RwProjectionCache implements ProjectionCache {
     private static final Logger log = LoggerFactory.getLogger(RwProjectionCache.class);
 


### PR DESCRIPTION
Also:
- Reduce visibility of sufficiently isolated implementation details from `public` to `package-private`
  - `RepositoryCacheImpl` is now `package-private` (use `RepositoryCache.create()` instead!)
- Get rid of Lombok `@UtilityClass` (which is buggy) and prohibit its future usage