### PR TITLE
WIP: Use better and simpler logic for "default sort order", Deprecate most usages of TypeToken trickery

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/InternalApi.java
+++ b/databind/src/main/java/tech/ydb/yoj/InternalApi.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
  * Annotates internal YOJ implementation details (classes, interfaces, methods, fields, constants, etc.) that need to be
  * {@code public} to be used from different and/or multiple packages, but are not stable even across minor YOJ releases.
  * <p>Non-{@code public} (e.g., package-private) classes, interfaces, methods, fields, constants etc. in YOJ are assumed
- * to be internal implementation details regardless of the presence of an {@code &#64;InternalApi} annotation on them.
+ * to be internal implementation details regardless of the presence of an {@code @InternalApi} annotation on them.
  */
 @Target({TYPE, FIELD, METHOD, PARAMETER, CONSTRUCTOR, ANNOTATION_TYPE, PACKAGE, MODULE, RECORD_COMPONENT})
 @Retention(SOURCE)

--- a/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/StdReflector.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/schema/reflect/StdReflector.java
@@ -49,7 +49,7 @@ public final class StdReflector implements Reflector {
     }
 
     private ReflectType<?> reflectFor(Type type, FieldValueType fvt) {
-        Class<?> rawType = TypeToken.of(type).getRawType();
+        Class<?> rawType = type instanceof Class<?> clazz ? clazz : TypeToken.of(type).getRawType();
         for (TypeFactory m : matchers) {
             if (m.matches(rawType, fvt)) {
                 return m.create(this, rawType, fvt);

--- a/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryRepositoryTransaction.java
+++ b/repository-inmemory/src/main/java/tech/ydb/yoj/repository/test/inmemory/InMemoryRepositoryTransaction.java
@@ -3,6 +3,7 @@ package tech.ydb.yoj.repository.test.inmemory;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Iterables;
 import lombok.Getter;
+import tech.ydb.yoj.DeprecationWarnings;
 import tech.ydb.yoj.repository.BaseDb;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.RepositoryTransaction;
@@ -57,7 +58,7 @@ public class InMemoryRepositoryTransaction implements BaseDb, RepositoryTransact
 
     @Override
     public <T extends Entity<T>> Table<T> table(Class<T> c) {
-        return new InMemoryTable<>(getMemory(c));
+        return new InMemoryTable<>(this, c);
     }
 
     @Override
@@ -65,8 +66,13 @@ public class InMemoryRepositoryTransaction implements BaseDb, RepositoryTransact
         return new InMemoryTable<>(this, tableDescriptor);
     }
 
-    @Deprecated // use other constructor of InMemoryTable
+    /**
+     * @deprecated {@code DbMemory} and this method will be removed in YOJ 3.0.0.
+     */
+    @Deprecated(forRemoval = true)
     public final <T extends Entity<T>> InMemoryTable.DbMemory<T> getMemory(Class<T> c) {
+        DeprecationWarnings.warnOnce("InMemoryTable.getMemory",
+                "InMemoryTable.getMemory(Class<T>) will be removed in YOJ 3.0.0. Please stop using this method"); 
         return new InMemoryTable.DbMemory<>(c, this);
     }
 

--- a/repository-inmemory/src/test/java/tech/ydb/yoj/repository/test/inmemory/TestInMemoryRepository.java
+++ b/repository-inmemory/src/test/java/tech/ydb/yoj/repository/test/inmemory/TestInMemoryRepository.java
@@ -105,7 +105,7 @@ public class TestInMemoryRepository extends InMemoryRepository {
 
         @Override
         public Supabubble2Table supabubbles2() {
-            return new Supabubble2InMemoryTable(getMemory(Supabubble2.class));
+            return new Supabubble2InMemoryTable(this, Supabubble2.class);
         }
 
         @Override
@@ -145,8 +145,8 @@ public class TestInMemoryRepository extends InMemoryRepository {
     }
 
     private static class Supabubble2InMemoryTable extends InMemoryTable<Supabubble2> implements TestEntityOperations.Supabubble2Table {
-        public Supabubble2InMemoryTable(DbMemory<Supabubble2> memory) {
-            super(memory);
+        public Supabubble2InMemoryTable(InMemoryRepositoryTransaction transaction, Class<Supabubble2> type) {
+            super(transaction, type);
         }
     }
 

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/ListingTest.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/ListingTest.java
@@ -1,6 +1,5 @@
 package tech.ydb.yoj.repository.test;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import tech.ydb.yoj.databind.expression.FilterExpression;
 import tech.ydb.yoj.databind.expression.OrderExpression;
@@ -10,7 +9,6 @@ import tech.ydb.yoj.repository.db.list.BadListingException.BadPageSize;
 import tech.ydb.yoj.repository.db.list.ListRequest;
 import tech.ydb.yoj.repository.db.list.ListRequest.ListingParams;
 import tech.ydb.yoj.repository.db.list.ListResult;
-import tech.ydb.yoj.repository.db.list.ViewListResult;
 import tech.ydb.yoj.repository.test.entity.TestEntities;
 import tech.ydb.yoj.repository.test.sample.TestDb;
 import tech.ydb.yoj.repository.test.sample.TestDbImpl;
@@ -65,28 +63,28 @@ public abstract class ListingTest extends RepositoryTestSupport {
         OrderExpression<Project> orderBy = newOrderBuilder(Project.class).orderBy("name").descending().build();
         FilterExpression<Project> filter = newFilterBuilder(Project.class).where("name").in("AAA", "XXX", "ZZZ").build();
         db.tx(() -> {
-            ListResult<Project> page1 = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page1 = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(1)
                     .orderBy(orderBy)
                     .filter(filter)
                     .build());
-            Assertions.assertThat(page1).containsExactly(p3);
+            assertThat(page1).containsExactly(p3);
 
-            ListResult<Project> page2 = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page2 = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(1)
                     .orderBy(orderBy)
                     .filter(filter)
                     .offset(1)
                     .build());
-            Assertions.assertThat(page2).containsExactly(p2);
+            assertThat(page2).containsExactly(p2);
 
-            ListResult<Project> page3 = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page3 = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(1)
                     .orderBy(orderBy)
                     .filter(filter)
                     .offset(2)
                     .build());
-            Assertions.assertThat(page3).containsExactly(p1);
+            assertThat(page3).containsExactly(p1);
             assertThat(page3.isLastPage()).isTrue();
         });
     }
@@ -100,11 +98,11 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(ListRequest.builder(Complex.class)
+            ListResult<Complex> page = db.complexes().list(ListRequest.builder(Complex.class)
                     .pageSize(3)
                     .filter(fb -> fb.where("id.a").eq(999_999))
                     .build());
-            Assertions.assertThat(page).containsExactly(c3, c2, c1);
+            assertThat(page).containsExactly(c3, c2, c1);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -118,11 +116,11 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(ListRequest.builder(Complex.class)
+            ListResult<Complex> page = db.complexes().list(ListRequest.builder(Complex.class)
                     .pageSize(3)
                     .filter(fb -> fb.where("id.c").eq("UUU"))
                     .build());
-            Assertions.assertThat(page).containsExactly(c2);
+            assertThat(page).containsExactly(c2);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -131,7 +129,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
     public void failOnZeroPageSize() {
         db.tx(() -> {
             assertThatExceptionOfType(BadPageSize.class).isThrownBy(() ->
-                    listProjects(ListRequest.builder(Project.class)
+                    db.projects().list(ListRequest.builder(Project.class)
                             .pageSize(0)
                             .build()));
         });
@@ -141,7 +139,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
     public void failOnTooLargePageSize() {
         db.tx(() -> {
             assertThatExceptionOfType(BadPageSize.class).isThrownBy(() ->
-                    listProjects(ListRequest.builder(Project.class)
+                    db.projects().list(ListRequest.builder(Project.class)
                             .pageSize(100_000)
                             .build()));
         });
@@ -151,7 +149,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
     public void failOnTooLargeOffset() {
         db.tx(() -> {
             assertThatExceptionOfType(BadOffset.class).isThrownBy(() ->
-                    listProjects(ListRequest.builder(Project.class)
+                    db.projects().list(ListRequest.builder(Project.class)
                             .offset(10_001)
                             .build()));
         });
@@ -166,10 +164,10 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(ListRequest.builder(Complex.class)
+            ListResult<Complex> page = db.complexes().list(ListRequest.builder(Complex.class)
                     .pageSize(4)
                     .build());
-            Assertions.assertThat(page).containsExactly(c4, c3, c2, c1);
+            assertThat(page).containsExactly(c4, c3, c2, c1);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -184,11 +182,11 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, notInOutput));
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(ListRequest.builder(Complex.class)
+            ListResult<Complex> page = db.complexes().list(ListRequest.builder(Complex.class)
                     .pageSize(3)
                     .filter(fb -> fb.where("id.a").eq(1).and("id.b").gte(100L).and("id.b").lte(300L))
                     .build());
-            Assertions.assertThat(page).containsExactly(c1, c2, c3);
+            assertThat(page).containsExactly(c1, c2, c3);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -220,7 +218,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
                 .pageSize(1)
                 .build()));
 
-        Assertions.assertThat(lst).isEmpty();
+        assertThat(lst).isEmpty();
         assertThat(lst.isLastPage()).isTrue();
     }
 
@@ -263,12 +261,12 @@ public abstract class ListingTest extends RepositoryTestSupport {
         FilterExpression<Project> filter = newFilterBuilder(Project.class).where("id").in("uuid777", "uuid001", "uuid002").build();
         OrderExpression<Project> orderBy = newOrderBuilder(Project.class).orderBy("id").ascending().build();
         db.tx(() -> {
-            ListResult<Project> page = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(100)
                     .filter(filter)
                     .orderBy(orderBy)
                     .build());
-            Assertions.assertThat(page).containsExactlyInAnyOrder(p1, p2, p3);
+            assertThat(page).containsExactlyInAnyOrder(p1, p2, p3);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -282,17 +280,17 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(ListRequest.builder(Complex.class)
+            ListResult<Complex> page = db.complexes().list(ListRequest.builder(Complex.class)
                     .pageSize(100)
                     .filter(fb -> fb
-                            .where("id.a").in(999_999,999_000)
+                            .where("id.a").in(999_999, 999_000)
                             .and("id.b").in(15L, 13L)
                             .and("id.c").in("AAA", "CCC")
                             .and("id.d").in(Complex.Status.OK, Complex.Status.FAIL)
                     )
                     .orderBy(ob -> ob.orderBy("id").descending())
                     .build());
-            Assertions.assertThat(page).containsExactly(c1, c3);
+            assertThat(page).containsExactly(c1, c3);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -309,12 +307,12 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3));
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(ListRequest.builder(Complex.class)
+            ListResult<Complex> page = db.complexes().list(ListRequest.builder(Complex.class)
                     .pageSize(100)
-                    .filter(fb -> fb.where("id.a").in(999_999,999_000).and("id.b").gte(now).and("id.b").lt(nowPlus2))
+                    .filter(fb -> fb.where("id.a").in(999_999, 999_000).and("id.b").gte(now).and("id.b").lt(nowPlus2))
                     .orderBy(ob -> ob.orderBy("id.a").descending())
                     .build());
-            Assertions.assertThat(page).containsExactlyInAnyOrder(c1, c2);
+            assertThat(page).containsExactlyInAnyOrder(c1, c2);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -331,12 +329,12 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3));
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(ListRequest.builder(Complex.class)
+            ListResult<Complex> page = db.complexes().list(ListRequest.builder(Complex.class)
                     .pageSize(100)
-                    .filter(fb -> fb.where("id.a").in(999_999,999_000).and("id.b").in(now, nowPlus2))
+                    .filter(fb -> fb.where("id.a").in(999_999, 999_000).and("id.b").in(now, nowPlus2))
                     .orderBy(ob -> ob.orderBy("id.a").descending())
                     .build());
-            Assertions.assertThat(page).containsExactly(c1, c3);
+            assertThat(page).containsExactly(c1, c3);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -349,13 +347,13 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, notInOutput));
 
         db.tx(() -> {
-            ListResult<Project> page = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(100)
                     .filter(newFilterBuilder(Project.class)
                             .where("id").eq("uuid002").or("id").eq("uuid777")
                             .build())
                     .build());
-            Assertions.assertThat(page).containsExactly(p1, p2);
+            assertThat(page).containsExactly(p1, p2);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -368,13 +366,13 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, inOutput));
 
         db.tx(() -> {
-            ListResult<Project> page = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(100)
                     .filter(not(newFilterBuilder(Project.class)
                             .where("id").eq("uuid002").or("id").eq("uuid777")
                             .build()))
                     .build());
-            Assertions.assertThat(page).containsExactly(inOutput);
+            assertThat(page).containsExactly(inOutput);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -387,13 +385,13 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, inOutput));
 
         db.tx(() -> {
-            ListResult<Project> page = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(100)
                     .filter(not(newFilterBuilder(Project.class)
                             .where("id").gt("uuid002")
                             .build()))
                     .build());
-            Assertions.assertThat(page).containsExactly(p1);
+            assertThat(page).containsExactly(p1);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -406,13 +404,13 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, inOutput));
 
         db.tx(() -> {
-            ListResult<Project> page = listProjects(ListRequest.builder(Project.class)
+            ListResult<Project> page = db.projects().list(ListRequest.builder(Project.class)
                     .pageSize(100)
                     .filter(not(newFilterBuilder(Project.class)
                             .where("id").in("uuid002", "uuid777")
                             .build()))
                     .build());
-            Assertions.assertThat(page).containsExactly(inOutput);
+            assertThat(page).containsExactly(inOutput);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -462,13 +460,13 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.typeFreaks().insert(tf));
 
         db.tx(() -> {
-            ListResult<TypeFreak> page = listTypeFreak(ListRequest.builder(TypeFreak.class)
+            ListResult<TypeFreak> page = db.typeFreaks().list(ListRequest.builder(TypeFreak.class)
                     .pageSize(50)
                     .filter(newFilterBuilder(TypeFreak.class)
                             .where("customNamedColumn").eq("CUSTOM NAMED COLUMN")
                             .build())
                     .build());
-            Assertions.assertThat(page).containsExactly(tf);
+            assertThat(page).containsExactly(tf);
             assertThat(page.isLastPage()).isTrue();
         });
     }
@@ -479,7 +477,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.typeFreaks().insert(typeFreak));
 
         db.tx(() -> {
-            ListResult<TypeFreak> page = listTypeFreak(ListRequest.builder(TypeFreak.class)
+            ListResult<TypeFreak> page = db.typeFreaks().list(ListRequest.builder(TypeFreak.class)
                     .pageSize(100)
                     .filter(newFilterBuilder(TypeFreak.class)
                             .where("ticket").eq("CLOUD-100500")
@@ -496,7 +494,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.typeFreaks().insert(typeFreak));
 
         db.tx(() -> {
-            ListResult<TypeFreak> page = listTypeFreak(ListRequest.builder(TypeFreak.class)
+            ListResult<TypeFreak> page = db.typeFreaks().list(ListRequest.builder(TypeFreak.class)
                     .pageSize(100)
                     .filter(newFilterBuilder(TypeFreak.class)
                             .where("stringValueWrapper").eq("svw 123")
@@ -514,7 +512,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.typeFreaks().insert(typeFreak));
 
         db.tx(() -> {
-            ListResult<TypeFreak> page = listTypeFreak(ListRequest.builder(TypeFreak.class)
+            ListResult<TypeFreak> page = db.typeFreaks().list(ListRequest.builder(TypeFreak.class)
                     .pageSize(100)
                     .filter(newFilterBuilder(TypeFreak.class)
                             .where("ticket").eq(ticket)
@@ -534,7 +532,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.logEntries().insert(e1, e2, notInOutput, e3));
 
         db.tx(() -> {
-            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+            ListResult<LogEntry> page = db.logEntries().list(ListRequest.builder(LogEntry.class)
                     .pageSize(100)
                     .filter(fb -> fb.where("message").contains("msg"))
                     .build());
@@ -552,7 +550,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.logEntries().insert(e1, e2, inOutput, e3));
 
         db.tx(() -> {
-            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+            ListResult<LogEntry> page = db.logEntries().list(ListRequest.builder(LogEntry.class)
                     .pageSize(100)
                     .filter(fb -> fb.where("message").doesNotContain("msg"))
                     .build());
@@ -570,7 +568,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.logEntries().insert(e1, e2, notInOutput, e3));
 
         db.tx(() -> {
-            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+            ListResult<LogEntry> page = db.logEntries().list(ListRequest.builder(LogEntry.class)
                     .pageSize(100)
                     .filter(fb -> fb.where("message").contains("%_"))
                     .build());
@@ -588,7 +586,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.logEntries().insert(e1, e2, notInOutput, e3));
 
         db.tx(() -> {
-            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+            ListResult<LogEntry> page = db.logEntries().list(ListRequest.builder(LogEntry.class)
                     .pageSize(100)
                     .filter(fb -> fb.where("message").startsWith("#tag"))
                     .build());
@@ -606,7 +604,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.logEntries().insert(e1, e2, notInOutput, e3));
 
         db.tx(() -> {
-            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+            ListResult<LogEntry> page = db.logEntries().list(ListRequest.builder(LogEntry.class)
                     .pageSize(100)
                     .filter(fb -> fb.where("message").startsWith("%_"))
                     .build());
@@ -624,7 +622,7 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.logEntries().insert(e1, e2, inOutput, e3));
 
         db.tx(() -> {
-            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+            ListResult<LogEntry> page = db.logEntries().list(ListRequest.builder(LogEntry.class)
                     .pageSize(100)
                     .filter(fb -> fb.where("message").endsWith(" #tag"))
                     .build());
@@ -642,32 +640,12 @@ public abstract class ListingTest extends RepositoryTestSupport {
         db.tx(() -> db.logEntries().insert(e1, e2, notInOutput, e3));
 
         db.tx(() -> {
-            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+            ListResult<LogEntry> page = db.logEntries().list(ListRequest.builder(LogEntry.class)
                     .pageSize(100)
                     .filter(fb -> fb.where("message").endsWith("%_"))
                     .build());
             assertThat(page).containsExactly(e1, e3);
             assertThat(page.isLastPage()).isTrue();
         });
-    }
-
-    protected final ListResult<Project> listProjects(ListRequest<Project> request) {
-        return db.projects().list(request);
-    }
-
-    protected final ListResult<Complex> listComplex(ListRequest<Complex> request) {
-        return db.complexes().list(request);
-    }
-
-    protected final ListResult<TypeFreak> listTypeFreak(ListRequest<TypeFreak> request) {
-        return db.typeFreaks().list(request);
-    }
-
-    protected final ListResult<LogEntry> listLogEntries(ListRequest<LogEntry> request) {
-        return db.logEntries().list(request);
-    }
-
-    protected final ViewListResult<LogEntry, LogEntry.Message> listLogMessages(ListRequest<LogEntry> request) {
-        return db.logEntries().list(LogEntry.Message.class, request);
     }
 }

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/TableQueryBuilderTest.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/TableQueryBuilderTest.java
@@ -1,12 +1,7 @@
 package tech.ydb.yoj.repository.test;
 
-import lombok.NonNull;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.Repository;
-import tech.ydb.yoj.repository.db.Table;
-import tech.ydb.yoj.repository.db.TableQueryBuilder;
 import tech.ydb.yoj.repository.test.entity.TestEntities;
 import tech.ydb.yoj.repository.test.sample.TestDb;
 import tech.ydb.yoj.repository.test.sample.TestDbImpl;
@@ -48,10 +43,6 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
 
     protected abstract Repository createTestRepository();
 
-    protected <T extends Entity<T>> TableQueryBuilder<T> createQueryBuilder(@NonNull Class<T> entityClass) {
-        return getQueryBuilder(db.table(entityClass));
-    }
-
     @Test
     public void basic() {
         Project p1 = new Project(new Project.Id("uuid002"), "AAA");
@@ -61,36 +52,36 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, notInOutput, p3));
 
         db.tx(() -> {
-            List<Project> page1 = projectQuery()
+            List<Project> page1 = db.projects().query()
                     .limit(1)
                     .orderBy(ob -> ob.orderBy("name").descending())
                     .filter(fb -> fb.where("name").in("AAA", "XXX", "ZZZ"))
                     .find();
-            Assertions.assertThat(page1).containsExactly(p3);
+            assertThat(page1).containsExactly(p3);
 
-            List<Project> page2 = projectQuery()
+            List<Project> page2 = db.projects().query()
                     .limit(1)
                     .orderBy(ob -> ob.orderBy("name").descending())
                     .filter(fb -> fb.where("name").in("AAA", "XXX", "ZZZ"))
                     .offset(1)
                     .find();
-            Assertions.assertThat(page2).containsExactly(p2);
+            assertThat(page2).containsExactly(p2);
 
-            List<Project> page3 = projectQuery()
+            List<Project> page3 = db.projects().query()
                     .limit(1)
                     .orderBy(ob -> ob.orderBy("name").descending())
                     .filter(fb -> fb.where("name").in("AAA", "XXX", "ZZZ"))
                     .offset(2)
                     .find();
-            Assertions.assertThat(page3).containsExactly(p1);
+            assertThat(page3).containsExactly(p1);
 
-            List<Project> page4 = projectQuery()
+            List<Project> page4 = db.projects().query()
                     .limit(1)
                     .orderBy(ob -> ob.orderBy("name").descending())
                     .filter(fb -> fb.where("name").in("AAA", "XXX", "ZZZ"))
                     .offset(3)
                     .find();
-            Assertions.assertThat(page4).isEmpty();
+            assertThat(page4).isEmpty();
         });
     }
 
@@ -103,11 +94,11 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            List<Complex> page = complexQuery()
+            List<Complex> page = db.complexes().query()
                     .limit(3)
                     .filter(fb -> fb.where("id.a").eq(999_999))
                     .find();
-            Assertions.assertThat(page).containsExactly(c3, c2, c1);
+            assertThat(page).containsExactly(c3, c2, c1);
         });
     }
 
@@ -120,11 +111,11 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            List<Complex> page = complexQuery()
+            List<Complex> page = db.complexes().query()
                     .limit(3)
                     .filter(fb -> fb.where("id.c").eq("UUU"))
                     .find();
-            Assertions.assertThat(page).containsExactly(c2);
+            assertThat(page).containsExactly(c2);
         });
     }
 
@@ -137,10 +128,10 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            List<Complex> page = complexQuery()
+            List<Complex> page = db.complexes().query()
                     .limit(4)
                     .find();
-            Assertions.assertThat(page).containsExactly(c4, c3, c2, c1);
+            assertThat(page).containsExactly(c4, c3, c2, c1);
         });
     }
 
@@ -154,17 +145,17 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, notInOutput));
 
         db.tx(() -> {
-            List<Complex> page = complexQuery()
+            List<Complex> page = db.complexes().query()
                     .limit(4)
                     .filter(fb -> fb.where("id.a").eq(1).and("id.b").gte(100L).and("id.b").lte(300L))
                     .find();
-            Assertions.assertThat(page).containsExactly(c1, c2, c3);
+            assertThat(page).containsExactly(c1, c2, c3);
         });
     }
 
     @Test
     public void enumParsing() {
-        db.tx(() -> getQueryBuilder(db.typeFreaks())
+        db.tx(() -> db.typeFreaks().query()
                 .where("status").eq(Status.DRAFT)
                 .orderBy(ob -> ob.orderBy("status").descending())
                 .limit(1)
@@ -176,7 +167,7 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         var tf = new TypeFreak(new TypeFreak.Id("b1p", 1), false, (byte) 0, (byte) 0, (short) 0, 0, 0, 0.0f, 0.0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         db.tx(() -> db.typeFreaks().insert(tf));
 
-        List<TypeFreak> lst = db.tx(() -> getQueryBuilder(db.typeFreaks())
+        List<TypeFreak> lst = db.tx(() -> db.typeFreaks().query()
                 .where("jsonEmbedded").isNull()
                 .limit(100)
                 .find());
@@ -188,7 +179,7 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         var tf = new TypeFreak(new TypeFreak.Id("b1p", 1), false, (byte) 0, (byte) 0, (short) 0, 0, 0, 0.0f, 0.0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, new TypeFreak.Embedded(new TypeFreak.A("A"), new TypeFreak.B("B")), null, null, null, null, null, null, null, null, null, null, null);
         db.tx(() -> db.typeFreaks().insert(tf));
 
-        List<TypeFreak> lst = db.tx(() -> getQueryBuilder(db.typeFreaks())
+        List<TypeFreak> lst = db.tx(() -> db.typeFreaks().query()
                 .where("jsonEmbedded").isNotNull()
                 .limit(100)
                 .find());
@@ -199,12 +190,12 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
     public void filterStringValuedByString() {
         TypeFreak typeFreak = new TypeFreak(new TypeFreak.Id("b1p", 1), false, (byte) 0, (byte) 0, (short) 0, 0, 0, 0.0f, 0.0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, new TypeFreak.Ticket("CLOUD", 100500));
         db.tx(() -> db.typeFreaks().insert(typeFreak));
-        List<TypeFreak> lst = db.tx(() -> getQueryBuilder(db.typeFreaks())
+        List<TypeFreak> lst = db.tx(() -> db.typeFreaks().query()
                 .filter(fb -> fb.where("ticket").eq("CLOUD-100500"))
                 .limit(1)
                 .find());
 
-        Assertions.assertThat(lst).containsOnly(typeFreak);
+        assertThat(lst).containsOnly(typeFreak);
     }
 
     @Test
@@ -212,14 +203,14 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         TypeFreak.Ticket ticket = new TypeFreak.Ticket("CLOUD", 100500);
         TypeFreak typeFreak = new TypeFreak(new TypeFreak.Id("b1p", 1), false, (byte) 0, (byte) 0, (short) 0, 0, 0, 0.0f, 0.0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, ticket);
         db.tx(() -> db.typeFreaks().insert(typeFreak));
-        List<TypeFreak> lst = db.tx(() -> getQueryBuilder(db.typeFreaks())
+        List<TypeFreak> lst = db.tx(() -> db.typeFreaks().query()
                 .filter(newFilterBuilder(TypeFreak.class)
                         .where("ticket").eq(ticket)
                         .build())
                 .limit(1)
                 .find());
 
-        Assertions.assertThat(lst).containsOnly(typeFreak);
+        assertThat(lst).containsOnly(typeFreak);
     }
 
     @Test
@@ -227,12 +218,12 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.typeFreaks().insert(
                 new TypeFreak(new TypeFreak.Id("b1p", 1), false, (byte) 0, (byte) 0, (short) 0, 0, 0, 0.0f, 0.0, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)
         ));
-        List<TypeFreak> lst = db.tx(() -> getQueryBuilder(db.typeFreaks())
+        List<TypeFreak> lst = db.tx(() -> db.typeFreaks().query()
                 .filter(fb -> fb.where("embedded.a.a").eq("myfqdn"))
                 .limit(1)
                 .find());
 
-        Assertions.assertThat(lst).isEmpty();
+        assertThat(lst).isEmpty();
     }
 
     @Test
@@ -244,12 +235,12 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, notInOutput, p3));
 
         db.tx(() -> {
-            List<Project> page = projectQuery()
+            List<Project> page = db.projects().query()
                     .limit(100)
                     .filter(fb -> fb.where("id").in("uuid777", "uuid001", "uuid002"))
                     .orderBy(ob -> ob.orderBy("id").ascending())
                     .find();
-            Assertions.assertThat(page).containsExactlyInAnyOrder(p1, p2, p3);
+            assertThat(page).containsExactlyInAnyOrder(p1, p2, p3);
         });
     }
 
@@ -262,7 +253,7 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
 
         db.tx(() -> {
-            List<Complex> page = complexQuery()
+            List<Complex> page = db.complexes().query()
                     .limit(100)
                     .filter(fb -> fb
                             .where("id.a").in(999_999,999_000)
@@ -272,7 +263,7 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
                     )
                     .orderBy(ob -> ob.orderBy("id").descending())
                     .find();
-            Assertions.assertThat(page).containsExactly(c1, c3);
+            assertThat(page).containsExactly(c1, c3);
         });
     }
 
@@ -288,12 +279,12 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3));
 
         db.tx(() -> {
-            List<Complex> page = complexQuery()
+            List<Complex> page = db.complexes().query()
                     .limit(100)
                     .filter(fb -> fb.where("id.a").in(999_999,999_000).and("id.b").gte(now).and("id.b").lt(nowPlus2))
                     .orderBy(ob -> ob.orderBy("id.a").descending())
                     .find();
-            Assertions.assertThat(page).containsExactlyInAnyOrder(c1, c2);
+            assertThat(page).containsExactlyInAnyOrder(c1, c2);
         });
     }
 
@@ -309,12 +300,12 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.complexes().insert(c1, c2, c3));
 
         db.tx(() -> {
-            List<Complex> page = complexQuery()
+            List<Complex> page = db.complexes().query()
                     .limit(100)
                     .filter(fb -> fb.where("id.a").in(999_999, 999_000).and("id.b").in(now, nowPlus2))
                     .orderBy(ob -> ob.orderBy("id.a").descending())
                     .find();
-            Assertions.assertThat(page).containsExactly(c1, c3);
+            assertThat(page).containsExactly(c1, c3);
         });
     }
 
@@ -326,12 +317,12 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, notInOutput));
 
         db.tx(() -> {
-            List<Project> page = projectQuery()
+            List<Project> page = db.projects().query()
                     .where("id").eq("uuid002")
                     .or("id").eq("uuid777")
                     .limit(100)
                     .find();
-            Assertions.assertThat(page).containsExactly(p1, p2);
+            assertThat(page).containsExactly(p1, p2);
         });
     }
 
@@ -343,13 +334,13 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, inOutput));
 
         db.tx(() -> {
-            List<Project> page = projectQuery()
+            List<Project> page = db.projects().query()
                     .limit(100)
                     .filter(not(newFilterBuilder(Project.class)
                             .where("id").eq("uuid002").or("id").eq("uuid777")
                             .build()))
                     .find();
-            Assertions.assertThat(page).containsExactly(inOutput);
+            assertThat(page).containsExactly(inOutput);
         });
     }
 
@@ -361,13 +352,13 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, inOutput));
 
         db.tx(() -> {
-            List<Project> page = projectQuery()
+            List<Project> page = db.projects().query()
                     .limit(100)
                     .filter(not(newFilterBuilder(Project.class)
                             .where("id").gt("uuid002")
                             .build()))
                     .find();
-            Assertions.assertThat(page).containsExactly(p1);
+            assertThat(page).containsExactly(p1);
         });
     }
 
@@ -379,13 +370,13 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.projects().insert(p1, p2, inOutput));
 
         db.tx(() -> {
-            List<Project> page = projectQuery()
+            List<Project> page = db.projects().query()
                     .limit(100)
                     .filter(not(newFilterBuilder(Project.class)
                             .where("id").in("uuid002", "uuid777")
                             .build()))
                     .find();
-            Assertions.assertThat(page).containsExactly(inOutput);
+            assertThat(page).containsExactly(inOutput);
         });
     }
 
@@ -434,11 +425,11 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
         db.tx(() -> db.typeFreaks().insert(tf));
 
         db.tx(() -> {
-            List<TypeFreak> page = typeFreakQuery()
+            List<TypeFreak> page = db.typeFreaks().query()
                     .limit(50)
                     .where("customNamedColumn").eq("CUSTOM NAMED COLUMN")
                     .find();
-            Assertions.assertThat(page).containsExactly(tf);
+            assertThat(page).containsExactly(tf);
             assertThat(page.size() < 50).isTrue();
         });
     }
@@ -511,21 +502,5 @@ public abstract class TableQueryBuilderTest extends RepositoryTestSupport {
                 .and("id").eq(p2.getId())    // funny way to write ...AND id='...'
                 .find()
         )).isEmpty();
-    }
-
-    protected <T extends Entity<T>> TableQueryBuilder<T> getQueryBuilder(@NonNull Table<T> table) {
-        return new TableQueryBuilder<>(table);
-    }
-
-    protected final TableQueryBuilder<Project> projectQuery() {
-        return createQueryBuilder(Project.class);
-    }
-
-    protected final TableQueryBuilder<Complex> complexQuery() {
-        return createQueryBuilder(Complex.class);
-    }
-
-    protected final TableQueryBuilder<TypeFreak> typeFreakQuery() {
-        return createQueryBuilder(TypeFreak.class);
     }
 }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/FindRangeStatement.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/statement/FindRangeStatement.java
@@ -1,5 +1,6 @@
 package tech.ydb.yoj.repository.ydb.statement;
 
+import com.google.common.base.Preconditions;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import tech.ydb.proto.ValueProtos;
@@ -31,6 +32,9 @@ public class FindRangeStatement<ENTITY extends Entity<ENTITY>, ID extends Entity
             Range<ID> range
     ) {
         super(tableDescriptor, schema, outSchema);
+        Preconditions.checkArgument(range.getType() == schema.getIdSchema(),
+                "ID schema mismatch: Range was constructed with a different ID schema than the YdbTable");
+
         this.params = Stream.of(RangeBound.values())
                 .flatMap(b -> toParams(b.map(range).keySet(), b))
                 .collect(toList());

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/TestYdbRepository.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/TestYdbRepository.java
@@ -170,7 +170,7 @@ public class TestYdbRepository extends YdbRepository {
 
     private static class YdbSupabubble2Table extends YdbTable<Supabubble2> implements TestEntityOperations.Supabubble2Table {
         protected YdbSupabubble2Table(QueryExecutor executor) {
-            super(executor);
+            super(Supabubble2.class, executor);
         }
 
         @Override
@@ -181,7 +181,7 @@ public class TestYdbRepository extends YdbRepository {
 
     private static class ComplexTableImpl extends YdbTable<Complex> implements ComplexTable {
         protected ComplexTableImpl(QueryExecutor executor) {
-            super(executor);
+            super(Complex.class, executor);
         }
 
         @Override
@@ -192,7 +192,7 @@ public class TestYdbRepository extends YdbRepository {
 
     private static class BubbleTableImpl extends YdbTable<Bubble> implements BubbleTable {
         protected BubbleTableImpl(QueryExecutor executor) {
-            super(executor);
+            super(Bubble.class, executor);
         }
 
         @Override
@@ -203,7 +203,7 @@ public class TestYdbRepository extends YdbRepository {
 
     private static class IndexedTableImpl extends YdbTable<IndexedEntity> implements IndexedTable {
         protected IndexedTableImpl(QueryExecutor executor) {
-            super(executor);
+            super(IndexedEntity.class, executor);
         }
 
         @Override

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/list/YdbListingIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/list/YdbListingIntegrationTest.java
@@ -41,7 +41,7 @@ public class YdbListingIntegrationTest extends ListingTest {
         assertThat(predicate.toYql(EntitySchema.of(Complex.class))).isEqualTo("(`id_a` = ?) AND (`id_b` = ?)");
 
         db.tx(() -> {
-            ListResult<Complex> page = listComplex(listRequest);
+            ListResult<Complex> page = db.complexes().list(listRequest);
             assertThat(page).containsExactly(c3, c2, c1);
             assertThat(page.isLastPage()).isTrue();
         });

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/statement/FindInStatementTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/statement/FindInStatementTest.java
@@ -45,7 +45,7 @@ public class FindInStatementTest {
     private static final Set<?> NOT_INDEXED_KEYS = Set.of(FooIndexKey.of(1L, null, null));
     private static final Set<?> INCONSISTENT_TYPE_KEYS = Set.of(FooIndexKeyInconsistentType.of(100500L));
 
-    private static final OrderExpression<Foo> DEFAULT_ORDER = defaultOrder(Foo.class);
+    private static final OrderExpression<Foo> DEFAULT_ORDER = defaultOrder(ENTITY_SCHEMA);
 
     private static final String INDEX_NAME = "index_by_value";
     private static final String NOT_EXISTENT_INDEX_NAME = "not_existent_index";

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/AbstractDelegatingTable.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/AbstractDelegatingTable.java
@@ -3,6 +3,7 @@ package tech.ydb.yoj.repository.db;
 import com.google.common.reflect.TypeToken;
 import lombok.AccessLevel;
 import lombok.Getter;
+import tech.ydb.yoj.DeprecationWarnings;
 import tech.ydb.yoj.ExperimentalApi;
 import tech.ydb.yoj.databind.expression.FilterExpression;
 import tech.ydb.yoj.databind.expression.OrderExpression;
@@ -23,8 +24,22 @@ public abstract class AbstractDelegatingTable<T extends Entity<T>> implements Ta
         this.target = target;
     }
 
+    /**
+     * @deprecated This constructor uses reflection tricks to guess entity type for the table,
+     * and will be removed in YOJ 3.0.0.
+     * Please use {@link AbstractDelegatingTable#AbstractDelegatingTable(Class)} or
+     * {@link AbstractDelegatingTable#AbstractDelegatingTable(TableDescriptor)} instead.
+     */
+    @Deprecated(forRemoval = true)
     protected AbstractDelegatingTable() {
+        DeprecationWarnings.warnOnce("new AbstractDelegatingTable()",
+                "Nullary AbstractDelegatingTable constructor will be removed in YOJ 3.0.0. "
+                + "Please use 1-arg Class<T> or TableDescriptor<T> constructor instead");
         this.target = BaseDb.current(BaseDb.class).table(resolveEntityType());
+    }
+
+    protected AbstractDelegatingTable(Class<T> entityType) {
+        this.target = BaseDb.current(BaseDb.class).table(entityType);
     }
 
     @ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/32")
@@ -36,6 +51,11 @@ public abstract class AbstractDelegatingTable<T extends Entity<T>> implements Ta
     private Class<T> resolveEntityType() {
         return (Class<T>) (new TypeToken<T>(getClass()) {
         }).getRawType();
+    }
+
+    @Override
+    public TableQueryBuilder<T> query() {
+        return target.query();
     }
 
     @Override

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/Entity.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/Entity.java
@@ -22,6 +22,17 @@ public interface Entity<E extends Entity<E>> extends Table.ViewId<E> {
         return (E) this;
     }
 
+    /**
+     * @deprecated Please <strong>do not use Projections in new code</strong>, use YDB secondary indexes where possible!
+     * <p>If secondary indexes lack the required functionality (e.g., you need a <em>dynamically computed index</em>),
+     * use a custom {@code AbstractDelegatingTable} subclass for your entity's table and override the {@code save()},
+     * {@code insert()} and {@code delete()} methods to effect changes to related entity or entities.
+     * <p>In the future, we will rework the projection functionality and will probably move it to a separate YOJ module
+     * (with a convenient superclass for your tables).
+     *
+     * @see <a href="https://github.com/ydb-platform/yoj-project/issues/77">GitHub Issue</a>
+     */
+    @Deprecated
     default List<Entity<?>> createProjections() {
         return List.of();
     }
@@ -55,17 +66,32 @@ public interface Entity<E extends Entity<E>> extends Table.ViewId<E> {
             return Tx.Current.get().getRepositoryTransaction().table(getType()).find(this, throwIfAbsent);
         }
 
+        /**
+         * @deprecated This method will be removed in YOJ 3.0.0. Please use other ways to get entity type.
+         */
         @SuppressWarnings("unchecked")
+        @Deprecated(forRemoval = true)
         default Class<E> getType() {
+            DeprecationWarnings.warnOnce(
+                    "Entity.Id.getType()",
+                    "You are using Entity.Id.getType() which will be removed in YOJ 3.0.0. Please use other ways to get entity type"
+            );
             return (Class<E>) new TypeToken<E>(getClass()) {
             }.getRawType();
         }
 
+        /**
+         * @deprecated This method will be removed in YOJ 3.0.0. Please use other ways to check if ID is partial
+         * (i.e., has some of its trailing components set to {@code null} to implicitly indicate an <em>ID range</em>.)
+         */
+        @Deprecated(forRemoval = true)
         default boolean isPartial() {
-            var schema = EntitySchema.of(getType()).getIdSchema();
-            var columns = schema.flattenFields();
-            var nonNullFields = schema.flatten(this);
-            return columns.size() > nonNullFields.size();
+            DeprecationWarnings.warnOnce(
+                    "Entity.Id.isPartial()",
+                    "You are using Entity.Id.isPartial() which will be removed in YOJ 3.0.0. " +
+                            "Please use other ways to check if ID is partial (i.e., has a suffix of nulls)"
+            );
+            return TableQueryImpl.isPartialId(this, EntitySchema.of(getType()));
         }
     }
 }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/Table.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/Table.java
@@ -284,9 +284,7 @@ public interface Table<T extends Entity<T>> {
         return count(null, filter);
     }
 
-    default TableQueryBuilder<T> query() {
-        return new TableQueryBuilder<>(this);
-    }
+    TableQueryBuilder<T> query();
 
     /**
      * @deprecated Blindly setting entity fields is not recommended. Use {@code Table.modifyIfPresent()} instead, unless you

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/TableQueryImpl.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/TableQueryImpl.java
@@ -1,10 +1,16 @@
 package tech.ydb.yoj.repository.db;
 
 import com.google.common.collect.Sets;
+import lombok.NonNull;
 import tech.ydb.yoj.InternalApi;
+import tech.ydb.yoj.databind.expression.FilterExpression;
+import tech.ydb.yoj.databind.expression.OrderExpression;
 import tech.ydb.yoj.repository.db.cache.FirstLevelCache;
 import tech.ydb.yoj.repository.db.list.ListRequest;
+import tech.ydb.yoj.util.function.StreamSupplier;
 
+import javax.annotation.Nullable;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -12,8 +18,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static tech.ydb.yoj.repository.db.list.InMemoryQueries.toComparator;
+import static tech.ydb.yoj.repository.db.list.InMemoryQueries.toPredicate;
 
 /**
  * Utility class for {@link Table} implementation; <strong>for internal use only</strong>.
@@ -26,14 +36,14 @@ public final class TableQueryImpl {
     }
 
     public static <E extends Entity<E>, ID extends Entity.Id<E>> List<E> find(
-            Table<E> table, FirstLevelCache<E> cache, Set<ID> ids
+            Table<E> table, EntitySchema<E> schema, FirstLevelCache<E> cache, Set<ID> ids
     ) {
         if (ids.isEmpty()) {
             return List.of();
         }
 
-        var orderBy = EntityExpressions.defaultOrder(table.getType());
-        var isPartialIdMode = ids.iterator().next().isPartial();
+        var orderBy = EntityExpressions.defaultOrder(schema);
+        var isPartialIdMode = isPartialId(ids.iterator().next(), schema);
 
         var foundInCache = ids.stream()
                 .filter(cache::containsKey)
@@ -71,7 +81,44 @@ public final class TableQueryImpl {
             Sets.difference(Sets.difference(ids, foundInDbIds), foundInCacheIds).forEach(cache::putEmpty);
         }
 
-        return merged.values().stream().sorted(EntityIdSchema.SORT_ENTITY_BY_ID).collect(Collectors.toList());
+        return merged.values().stream()
+                .sorted(getEntityByIdComparator(schema))
+                .collect(Collectors.toList());
+    }
+
+    public static <T extends Entity<T>> List<T> find(@NonNull StreamSupplier<T> streamSupplier,
+                                                     @NonNull EntitySchema<T> entitySchema,
+                                                     @Nullable FilterExpression<T> filter,
+                                                     @Nullable OrderExpression<T> orderBy,
+                                                     @Nullable Integer limit,
+                                                     @Nullable Long offset) {
+        if (limit == null && offset != null && offset > 0) {
+            throw new IllegalArgumentException("offset > 0 with limit=null is not supported");
+        }
+
+        try (Stream<T> stream = streamSupplier.stream()) {
+            Stream<T> foundStream = stream;
+            if (filter != null) {
+                foundStream = foundStream.filter(toPredicate(filter));
+            }
+            if (orderBy != null) {
+                foundStream = foundStream.sorted(toComparator(orderBy));
+            } else {
+                foundStream = foundStream.sorted(getEntityByIdComparator(entitySchema));
+            }
+
+            foundStream = foundStream.skip(offset == null ? 0L : offset);
+
+            if (limit != null) {
+                foundStream = foundStream.limit(limit);
+            }
+
+            return foundStream.collect(toList());
+        }
+    }
+
+    public static <E extends Entity<E>> Comparator<E> getEntityByIdComparator(EntitySchema<E> schema) {
+        return Comparator.comparing(Entity::getId, schema.getIdSchema());
     }
 
     public static <E extends Entity<E>> TableQueryBuilder<E> toQueryBuilder(Table<E> table, ListRequest<E> request) {
@@ -81,5 +128,12 @@ public final class TableQueryImpl {
                 .orderBy(request.getOrderBy())
                 .offset(request.getOffset())
                 .limit(request.getPageSize() + 1);
+    }
+
+    public static <E extends Entity<E>, ID extends Entity.Id<E>> boolean isPartialId(ID id, EntitySchema<E> schema) {
+        var idSchema = schema.getIdSchema();
+        var columns = idSchema.flattenFields();
+        var nonNullFields = idSchema.flatten(id);
+        return columns.size() > nonNullFields.size();
     }
 }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/InMemoryQueries.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/InMemoryQueries.java
@@ -1,6 +1,7 @@
 package tech.ydb.yoj.repository.db.list;
 
 import lombok.NonNull;
+import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.databind.expression.AndExpr;
 import tech.ydb.yoj.databind.expression.FilterExpression;
 import tech.ydb.yoj.databind.expression.ListExpr;
@@ -13,6 +14,8 @@ import tech.ydb.yoj.databind.expression.values.FieldValue;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.databind.schema.Schema.JavaField;
 import tech.ydb.yoj.repository.db.Entity;
+import tech.ydb.yoj.repository.db.EntitySchema;
+import tech.ydb.yoj.repository.db.TableQueryImpl;
 import tech.ydb.yoj.util.function.StreamSupplier;
 
 import javax.annotation.Nullable;
@@ -36,10 +39,17 @@ import static tech.ydb.yoj.repository.db.EntityIdSchema.SORT_ENTITY_BY_ID;
 public final class InMemoryQueries {
     public static <T extends Entity<T>> ListResult<T> list(@NonNull StreamSupplier<T> streamSupplier,
                                                            @NonNull ListRequest<T> request) {
+        var schema = request.getSchema();
+        if (!(schema instanceof EntitySchema<T> entitySchema)) {
+            throw new IllegalArgumentException("Expected EntitySchema but got schema of type "
+                    + schema.getClass().getName());
+        }
+
         return ListResult.forPage(
                 request,
-                find(
+                TableQueryImpl.find(
                         streamSupplier,
+                        entitySchema,
                         request.getFilter(),
                         request.getOrderBy(),
                         request.getPageSize() + 1,
@@ -48,6 +58,14 @@ public final class InMemoryQueries {
         );
     }
 
+    /**
+     * @deprecated End-users should use {@link #list(StreamSupplier, ListRequest)} instead of this implementation detail.
+     * Internal YOJ implementation should instead call
+     * {@link tech.ydb.yoj.repository.db.TableQueryImpl#find(StreamSupplier, EntitySchema, FilterExpression, OrderExpression, Integer, Long)}.
+     * <p>This method will be removed in YOJ 2.7.0.
+     */
+    @InternalApi
+    @Deprecated(forRemoval = true)
     public static <T extends Entity<T>> List<T> find(@NonNull StreamSupplier<T> streamSupplier,
                                                      @Nullable FilterExpression<T> filter,
                                                      @Nullable OrderExpression<T> orderBy,

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/projection/RwProjectionCache.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/projection/RwProjectionCache.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.RepositoryTransaction;
+import tech.ydb.yoj.repository.db.Table;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -52,21 +53,28 @@ public class RwProjectionCache implements ProjectionCache {
 
         oldProjections.values().stream()
                 .filter(e -> !newProjections.containsKey(e.getId()))
-                .forEach(e -> deleteEntity(transaction, e.getId()));
+                .forEach(e -> deleteEntity(transaction, e));
         newProjections.values().stream()
                 .filter(e -> !e.equals(oldProjections.get(e.getId())))
                 .forEach(e -> saveEntity(transaction, e));
     }
 
-    private <T extends Entity<T>> void deleteEntity(RepositoryTransaction transaction, Entity.Id<T> entityId) {
-        transaction.table(entityId.getType()).delete(entityId);
+    private <T extends Entity<T>> void deleteEntity(RepositoryTransaction transaction, Entity<T> entity) {
+        table(transaction, entity).delete(entity.getId());
     }
 
     private <T extends Entity<T>> void saveEntity(RepositoryTransaction transaction, Entity<T> entity) {
         @SuppressWarnings("unchecked")
         T castedEntity = (T) entity;
 
-        transaction.table(entity.getId().getType()).save(castedEntity);
+        table(transaction, entity).save(castedEntity);
+    }
+
+    private <T extends Entity<T>> Table<T> table(RepositoryTransaction transaction, Entity<T> entity) {
+        @SuppressWarnings("unchecked")
+        Class<T> entityType = (Class<T>) entity.getClass();
+
+        return transaction.table(entityType);
     }
 
     private Entity<?> mergeOldProjections(Entity<?> p1, Entity<?> p2) {

--- a/repository/src/test/java/tech/ydb/yoj/repository/db/PojoEntityTest.java
+++ b/repository/src/test/java/tech/ydb/yoj/repository/db/PojoEntityTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class PojoEntityTest {
-
     @Value
     private static class Ent implements Entity<Ent> {
         @NonNull
@@ -24,10 +23,11 @@ public class PojoEntityTest {
 
     @Test
     public void testPartialId() {
+        var schema = EntitySchema.of(Ent.class);
         var completeId = new Ent.Id("a", "b");
         var partialId = new Ent.Id("a", null);
 
-        assertTrue(partialId.isPartial());
-        assertFalse(completeId.isPartial());
+        assertTrue(TableQueryImpl.isPartialId(partialId, schema));
+        assertFalse(TableQueryImpl.isPartialId(completeId, schema));
     }
 }

--- a/repository/src/test/java/tech/ydb/yoj/repository/db/RecordEntityTest.java
+++ b/repository/src/test/java/tech/ydb/yoj/repository/db/RecordEntityTest.java
@@ -14,10 +14,11 @@ public class RecordEntityTest {
 
     @Test
     public void testPartialId() {
+        var schema = EntitySchema.of(Ent.class);
         var completeId = new Ent.Id("a", "b");
         var partialId = new Ent.Id("a", null);
 
-        assertTrue(partialId.isPartial());
-        assertFalse(completeId.isPartial());
+        assertTrue(TableQueryImpl.isPartialId(partialId, schema));
+        assertFalse(TableQueryImpl.isPartialId(completeId, schema));
     }
 }


### PR DESCRIPTION
...because `Entity.Id.getType()` uses `TypeToken` which is **extremely slow** in tight loops when run via Bazel JUnit5 tests, which have a non-null `SecurityManager` installed (`SecurityManager` is to prevent `System.exit()` calls from tests, but it happens to check every reflective access made by `TypeToken`, of which there are **plenty**.)