### PR TITLE
IContains support

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/FilterBuilder.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/FilterBuilder.java
@@ -26,10 +26,12 @@ import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.ENDS_WITH;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.EQ;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.GT;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.GTE;
+import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.ICONTAINS;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.LT;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.LTE;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.NEQ;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.NOT_CONTAINS;
+import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.NOT_ICONTAINS;
 import static tech.ydb.yoj.databind.expression.ScalarExpr.Operator.STARTS_WITH;
 
 @RequiredArgsConstructor(access = PRIVATE)
@@ -258,6 +260,18 @@ public final class FilterBuilder<T> {
         @NonNull
         public FilterBuilder<T> doesNotContain(@NonNull String value) {
             current = finisher.apply(new ScalarExpr<>(schema, generated, field, NOT_CONTAINS, fieldValue(value)));
+            return FilterBuilder.this;
+        }
+
+        @NonNull
+        public FilterBuilder<T> iContains(@NonNull String value) {
+            current = finisher.apply(new ScalarExpr<>(schema, generated, field, ICONTAINS, fieldValue(value)));
+            return FilterBuilder.this;
+        }
+
+        @NonNull
+        public FilterBuilder<T> doesNotIContain(@NonNull String value) {
+            current = finisher.apply(new ScalarExpr<>(schema, generated, field, NOT_ICONTAINS, fieldValue(value)));
             return FilterBuilder.this;
         }
 

--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/ScalarExpr.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/ScalarExpr.java
@@ -249,6 +249,36 @@ public class ScalarExpr<T> extends LeafExpression<T> {
             public String toString() {
                 return "not contains";
             }
+        },
+        /**
+         * "Icontains" case-insensitive match for a substring in a string
+         * E.g., {@code name contains "abc"}
+         */
+        ICONTAINS {
+            @Override
+            public Operator negate() {
+                return NOT_ICONTAINS;
+            }
+
+            @Override
+            public String toString() {
+                return "icontains";
+            }
+        },
+        /**
+         * "Not icontains" case-insensitive absence of a substring in a string
+         * E.g., {@code name not icontains "abc"}
+         */
+        NOT_ICONTAINS {
+            @Override
+            public Operator negate() {
+                return ICONTAINS;
+            }
+
+            @Override
+            public String toString() {
+                return "not icontains";
+            }
         };
 
         @Nullable

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/ListingTest.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/ListingTest.java
@@ -544,6 +544,24 @@ public abstract class ListingTest extends RepositoryTestSupport {
     }
 
     @Test
+    public void iContains() {
+        LogEntry e1 = new LogEntry(new LogEntry.Id("log1", 1L), LogEntry.Level.ERROR, "earliest msg");
+        LogEntry notInOutput = new LogEntry(new LogEntry.Id("log2", 2L), LogEntry.Level.DEBUG, "will be ignored");
+        LogEntry e2 = new LogEntry(new LogEntry.Id("log1", 4L), LogEntry.Level.WARN, "middle msg");
+        LogEntry e3 = new LogEntry(new LogEntry.Id("log1", 5L), LogEntry.Level.INFO, "latest msg");
+        db.tx(() -> db.logEntries().insert(e1, e2, notInOutput, e3));
+
+        db.tx(() -> {
+            ListResult<LogEntry> page = listLogEntries(ListRequest.builder(LogEntry.class)
+                    .pageSize(100)
+                    .filter(fb -> fb.where("message").iContains("MsG"))
+                    .build());
+            assertThat(page).containsExactly(e1, e2, e3);
+            assertThat(page.isLastPage()).isTrue();
+        });
+    }
+
+    @Test
     public void notContains() {
         LogEntry e1 = new LogEntry(new LogEntry.Id("log1", 1L), LogEntry.Level.ERROR, "earliest msg");
         LogEntry inOutput = new LogEntry(new LogEntry.Id("log2", 2L), LogEntry.Level.DEBUG, "will be ignored");

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlListingQuery.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlListingQuery.java
@@ -66,6 +66,8 @@ public final class YqlListingQuery {
                     case GTE -> pred.gte(expected);
                     case CONTAINS -> pred.like(likePatternForContains((String) expected), LIKE_ESCAPE_CHAR);
                     case NOT_CONTAINS -> pred.notLike(likePatternForContains((String) expected), LIKE_ESCAPE_CHAR);
+                    case ICONTAINS -> pred.iLike(likePatternForContains((String) expected), LIKE_ESCAPE_CHAR);
+                    case NOT_ICONTAINS -> pred.notILike(likePatternForContains((String) expected), LIKE_ESCAPE_CHAR);
                     case STARTS_WITH -> pred.like(likePatternForStartsWith((String) expected), LIKE_ESCAPE_CHAR);
                     case ENDS_WITH -> pred.like(likePatternForEndsWith((String) expected), LIKE_ESCAPE_CHAR);
                 };

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlPredicate.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/yql/YqlPredicate.java
@@ -27,7 +27,9 @@ import static java.util.stream.Collectors.toList;
 import static lombok.AccessLevel.PRIVATE;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.IsNullPredicate.IsNullType.IS_NOT_NULL;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.IsNullPredicate.IsNullType.IS_NULL;
+import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.LikePredicate.Type.ILIKE;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.LikePredicate.Type.LIKE;
+import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.LikePredicate.Type.NOT_ILIKE;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.LikePredicate.Type.NOT_LIKE;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.Rel.EQ;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.Rel.GT;
@@ -186,6 +188,22 @@ public abstract class YqlPredicate implements YqlStatementPart<YqlPredicate> {
 
     public static YqlPredicate notLike(@NonNull String fieldPath, @NonNull String value, @Nullable Character escape) {
         return new LikePredicate<>(NOT_LIKE, fieldPath, value, escape);
+    }
+
+    public static YqlPredicate iLike(@NonNull String fieldPath, @NonNull String value) {
+        return iLike(fieldPath, value, null);
+    }
+
+    public static YqlPredicate iLike(@NonNull String fieldPath, @NonNull String value, @Nullable Character escape) {
+        return new LikePredicate<>(ILIKE, fieldPath, value, escape);
+    }
+
+    public static YqlPredicate notILike(@NonNull String fieldPath, @NonNull String value) {
+        return notILike(fieldPath, value, null);
+    }
+
+    public static YqlPredicate notILike(@NonNull String fieldPath, @NonNull String value, @Nullable Character escape) {
+        return new LikePredicate<>(NOT_ILIKE, fieldPath, value, escape);
     }
 
     public static YqlPredicate alwaysTrue() {
@@ -571,6 +589,28 @@ public abstract class YqlPredicate implements YqlStatementPart<YqlPredicate> {
                 public Type negate() {
                     return LIKE;
                 }
+            },
+            ILIKE {
+                @Override
+                public String toYql() {
+                    return "ILIKE";
+                }
+
+                @Override
+                public Type negate() {
+                    return NOT_ILIKE;
+                }
+            },
+            NOT_ILIKE {
+                @Override
+                public String toYql() {
+                    return "NOT ILIKE";
+                }
+
+                @Override
+                public Type negate() {
+                    return ILIKE;
+                }
             };
 
             public abstract String toYql();
@@ -937,6 +977,22 @@ public abstract class YqlPredicate implements YqlStatementPart<YqlPredicate> {
 
         public YqlPredicate notLike(@NonNull String value, @Nullable Character escape) {
             return finisher.apply(YqlPredicate.notLike(fieldPath, value, escape));
+        }
+
+        public YqlPredicate iLike(@NonNull String value) {
+            return iLike(value, null);
+        }
+
+        public YqlPredicate iLike(@NonNull String value, @Nullable Character escape) {
+            return finisher.apply(YqlPredicate.iLike(fieldPath, value, escape));
+        }
+
+        public YqlPredicate notILike(@NonNull String value) {
+            return notILike(value, null);
+        }
+
+        public YqlPredicate notILike(@NonNull String value, @Nullable Character escape) {
+            return finisher.apply(YqlPredicate.notILike(fieldPath, value, escape));
         }
 
         public YqlPredicate isNull() {

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YqlPredicateTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YqlPredicateTest.java
@@ -15,12 +15,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.eq;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.gt;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.gte;
+import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.iLike;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.in;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.like;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.lt;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.lte;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.neq;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.not;
+import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.notILike;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.notLike;
 import static tech.ydb.yoj.repository.ydb.yql.YqlPredicate.where;
 
@@ -99,6 +101,46 @@ public class YqlPredicateTest {
     }
 
     @Test
+    public void rel_iLike_fluent() {
+        assertThat(where("status").iLike("%OK%").toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ?");
+    }
+
+    @Test
+    public void rel_iLike_chained() {
+        assertThat(iLike("status", "%OK%").toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ?");
+    }
+
+    @Test
+    public void rel_not_iLike_fluent() {
+        assertThat(not(where("status").iLike("%OK%")).toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ?");
+    }
+
+    @Test
+    public void rel_not_iLike_chained() {
+        assertThat(not(iLike("status", "%OK%")).toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ?");
+    }
+
+    @Test
+    public void rel_notILike_fluent() {
+        assertThat(where("status").notILike("%OK%").toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ?");
+    }
+
+    @Test
+    public void rel_notILike_chained() {
+        assertThat(notILike("status", "%OK%").toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ?");
+    }
+
+    @Test
+    public void rel_not_notILike_fluent() {
+        assertThat(not(where("status").notILike("%OK%")).toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ?");
+    }
+
+    @Test
+    public void rel_not_notILike_chained() {
+        assertThat(not(notILike("status", "%OK%")).toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ?");
+    }
+
+    @Test
     public void rel_like_escape_fluent() {
         assertThat(where("status").like("%OK/_%", '/').toYql(schema)).isEqualToIgnoringCase("`status` LIKE ? ESCAPE '/'");
     }
@@ -136,6 +178,46 @@ public class YqlPredicateTest {
     @Test
     public void rel_not_notLike_escape_chained() {
         assertThat(not(notLike("status", "%OK/_%", '/')).toYql(schema)).isEqualToIgnoringCase("`status` LIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_iLike_escape_fluent() {
+        assertThat(where("status").iLike("%OK/_%", '/').toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_iLike_escape_chained() {
+        assertThat(iLike("status", "%OK/_%", '/').toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_not_iLike_escape_fluent() {
+        assertThat(not(where("status").iLike("%OK/_%", '/')).toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_not_iLike_escape_chained() {
+        assertThat(not(iLike("status", "%OK/_%", '/')).toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_notILike_escape_fluent() {
+        assertThat(where("status").notILike("%OK/_%", '/').toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_notILike_escape_chained() {
+        assertThat(notILike("status", "%OK/_%", '/').toYql(schema)).isEqualToIgnoringCase("`status` NOT ILIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_not_notILike_escape_fluent() {
+        assertThat(not(where("status").notILike("%OK/_%", '/')).toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ? ESCAPE '/'");
+    }
+
+    @Test
+    public void rel_not_notILike_escape_chained() {
+        assertThat(not(notILike("status", "%OK/_%", '/')).toYql(schema)).isEqualToIgnoringCase("`status` ILIKE ? ESCAPE '/'");
     }
 
     @Test

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/InMemoryQueries.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/InMemoryQueries.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
@@ -94,6 +95,8 @@ public final class InMemoryQueries {
                     case CONTAINS -> obj -> contains((String) getActual.apply(obj), (String) expected);
                     case NOT_CONTAINS -> obj -> !contains((String) getActual.apply(obj), (String) expected);
                     case STARTS_WITH -> obj -> startsWith((String) getActual.apply(obj), (String) expected);
+                    case ICONTAINS -> obj -> iContains((String) getActual.apply(obj), (String) expected);
+                    case NOT_ICONTAINS -> obj -> !iContains((String) getActual.apply(obj), (String) expected);
                     case ENDS_WITH -> obj -> endsWith((String) getActual.apply(obj), (String) expected);
                 };
             }
@@ -204,6 +207,15 @@ public final class InMemoryQueries {
         }
         return input.contains(substring);
     }
+
+    private static boolean iContains(@Nullable String input, @Nullable String substring) {
+        if (input == null || substring == null) {
+            return false;
+        }
+
+        return input.toLowerCase().contains(substring.toLowerCase());
+    }
+
 
     private static boolean startsWith(@Nullable String input, @Nullable String substring) {
         if (input == null || substring == null) {


### PR DESCRIPTION
It is convenient to use a case-insensitive filter as an additional search condition.
ydb itself supports ILIKE https://ydb.tech/docs/en/yql/reference/syntax/expressions#check-match
But the filters in YOJ are not.
It is proposed to add ICONTAINS along with CONTAINS

https://github.com/ydb-platform/yoj-project/issues/146