### PR TITLE
noticket: Customize default transaction name generation in `StdTxManager`

### DIFF
--- a/repository/src/main/java/tech/ydb/yoj/repository/db/StdTxManager.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/StdTxManager.java
@@ -24,7 +24,6 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -48,7 +47,7 @@ import static tech.ydb.yoj.repository.db.IsolationLevel.SERIALIZABLE_READ_WRITE;
 public final class StdTxManager implements TxManager, TxManagerState {
     /**
      * @deprecated Please stop using the {@code StdTxManager.useNewTxNameGeneration} field.
-     * Changing this field has no effect as of YOJ 2.6.1, and it will be <strong>removed completely</strong> in YOJ 3.0.0.
+     * Changing this field has no effect as of YOJ 2.6.1, and it will be <strong>removed completely</strong> in YOJ 2.7.0.
      */
     @Deprecated(forRemoval = true)
     public static volatile boolean useNewTxNameGeneration = true;
@@ -88,10 +87,6 @@ public final class StdTxManager implements TxManager, TxManagerState {
             .register();
     private static final AtomicLong txLogIdSeq = new AtomicLong();
 
-    private static final Pattern PACKAGE_PATTERN = Pattern.compile(".*\\.");
-    private static final Pattern INNER_CLASS_PATTERN = Pattern.compile("\\$.*");
-    private static final Pattern SHORTEN_NAME_PATTERN = Pattern.compile("([A-Z][a-z]{2})[a-z]+");
-
     @Getter
     private final Repository repository;
     @With(AccessLevel.PRIVATE)
@@ -109,11 +104,23 @@ public final class StdTxManager implements TxManager, TxManagerState {
     private final SeparatePolicy separatePolicy;
     @With
     private final Set<String> skipCallerPackages;
+    @With
+    private final TxNameGenerator txNameGenerator;
 
     private final long txLogId = txLogIdSeq.incrementAndGet();
 
-    public StdTxManager(Repository repository) {
-        this(repository, DEFAULT_MAX_ATTEMPT_COUNT, null, null, null, TxOptions.create(SERIALIZABLE_READ_WRITE), SeparatePolicy.LOG, Set.of());
+    public StdTxManager(@NonNull Repository repository) {
+        this(
+                /*         repository */ repository,
+                /*    maxAttemptCount */ DEFAULT_MAX_ATTEMPT_COUNT,
+                /*               name */ null,
+                /*            logLine */ null,
+                /*         logContext */ null,
+                /*            options */ TxOptions.create(SERIALIZABLE_READ_WRITE),
+                /*     separatePolicy */ SeparatePolicy.LOG,
+                /* skipCallerPackages */ Set.of(),
+                /*    txNameGenerator */ TxNameGenerator.SHORT
+        );
     }
 
     /**
@@ -122,7 +129,7 @@ public final class StdTxManager implements TxManager, TxManagerState {
      */
     @Deprecated(forRemoval = true)
     public StdTxManager(Repository repository, int maxAttemptCount, String name, Integer logLine, String logContext, TxOptions options) {
-        this(repository, maxAttemptCount, name, logLine, logContext, options, SeparatePolicy.LOG, Set.of());
+        this(repository, maxAttemptCount, name, logLine, logContext, options, SeparatePolicy.LOG, Set.of(), TxNameGenerator.SHORT);
         DeprecationWarnings.warnOnce("StdTxManager(Repository, int, String, Integer, String, TxOptions)",
                 "Please use the recommended StdTxManager(Repository) constructor and customize the TxManager by using with<...>() methods");
     }
@@ -286,32 +293,21 @@ public final class StdTxManager implements TxManager, TxManagerState {
 
         if (!useNewTxNameGeneration) {
             DeprecationWarnings.warnOnce("StdTxManager.useNewTxNameGeneration",
-                    "As of YOJ 2.6.1, setting StdTxManager.useNewTxNameGeneration has no effect. Please stop setting this field");
+                    "Setting StdTxManager.useNewTxNameGeneration has no effect. Please stop setting this field, it will be removed in YOJ 2.7.0");
         }
 
         var info = callStack.findCallingFrame()
                 .skipPackage(StdTxManager.class.getPackageName())
                 .skipPackages(skipCallerPackages)
-                .map(f -> new TxInfo(txName(f.getClassName(), f.getMethodName()), f.getLineNumber()));
+                .map(
+                        f -> new TxInfo(
+                                txNameGenerator.nameFor(f.getClassName(), f.getMethodName()),
+                                f.getLineNumber()
+                        ),
+                        txNameGenerator
+                );
 
         return withName(info.name).withLogLine(info.lineNumber);
-    }
-
-    @NonNull
-    private static String txName(String className, String methodName) {
-        var cn = replaceFirst(className, PACKAGE_PATTERN, "");
-        cn = replaceFirst(cn, INNER_CLASS_PATTERN, "");
-        cn = replaceAll(cn, SHORTEN_NAME_PATTERN, "$1");
-        var mn = replaceAll(methodName, SHORTEN_NAME_PATTERN, "$1");
-        return cn + '#' + mn;
-    }
-
-    private static String replaceFirst(String input, Pattern regex, String replacement) {
-        return regex.matcher(input).replaceFirst(replacement);
-    }
-
-    private static String replaceAll(String input, Pattern regex, String replacement) {
-        return regex.matcher(input).replaceAll(replacement);
     }
 
     private String formatTx() {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/TxImpl.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/TxImpl.java
@@ -87,7 +87,7 @@ final class TxImpl implements Tx {
 
         if (dryRun) {
             doRollback(true,
-                    String.format("[%s]" + "runInTx(): Rollback because dry-run transaction read inconsistent data", sw));
+                    String.format("[%s] runInTx(): Rollback because dry-run transaction read inconsistent data", sw));
             log.debug("[{}] runInTx(): Rollback due to dry-run mode {}", sw, formatExecutionLogMultiline("# "));
             return res;
         }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/TxNameGenerator.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/TxNameGenerator.java
@@ -1,0 +1,100 @@
+package tech.ydb.yoj.repository.db;
+
+import lombok.NonNull;
+
+import java.util.regex.Pattern;
+
+/**
+ * Generates default name for a transaction, depending on the caller class and caller method names.
+ */
+public interface TxNameGenerator {
+    /**
+     * @param className  caller class name
+     * @param methodName caller method name
+     * @return transaction name
+     */
+    @NonNull
+    String nameFor(@NonNull String className, @NonNull String methodName);
+
+    /**
+     * Generates short tx names of the form {@code ClNam#meNa} (from {@code package.name.ClassName[$InnerClassName]} and {@code methodName}).
+     * All inner class names are stripped out.
+     * <br>Such tx names can be used as-is as a search term in IntelliJ IDEA; IDEA will guide you to the correct method.
+     * If you take the transactions's whole {@link StdTxManager#getLogContext() log context}, it will include the line number,
+     * and IDEA will take you to the line where the transaction was spawned.
+     * <strong>The disadvantage is that short tx names are not particularly human-readable.</strong>
+     *
+     * <p>This is the classic YOJ default tx name generator, used since YOJ 1.0.0.
+     *
+     * @see #LONG
+     * @see #NONE
+     */
+    TxNameGenerator SHORT = new TxNameGenerator() {
+        private static final Pattern PACKAGE_PATTERN = Pattern.compile(".*\\.");
+        private static final Pattern INNER_CLASS_PATTERN_CLEAR = Pattern.compile("\\$.*");
+        private static final Pattern SHORTEN_NAME_PATTERN = Pattern.compile("([A-Z][a-z]{2})[a-z]+");
+
+        @NonNull
+        @Override
+        public String nameFor(@NonNull String className, @NonNull String methodName) {
+            var cn = replaceFirst(className, PACKAGE_PATTERN, "");
+            cn = replaceFirst(cn, INNER_CLASS_PATTERN_CLEAR, "");
+            cn = replaceAll(cn, SHORTEN_NAME_PATTERN, "$1");
+            var mn = replaceAll(methodName, SHORTEN_NAME_PATTERN, "$1");
+            return cn + '#' + mn;
+        }
+
+        @Override
+        public String toString() {
+            return "TxNameGenerator.SHORT";
+        }
+    };
+
+    /**
+     * Generates long transaction names of the form {@code ClassName.methodName[$InnerClassName]}
+     * (from {@code package.name.ClassName[$InnerClassName]} and {@code methodName}).
+     * Inner class names, including anonymous class names, are kept in the {@code Class.getName()} format ({@code $<inner class name>}).
+     *
+     * @see #SHORT
+     * @see #NONE
+     */
+    TxNameGenerator LONG = new TxNameGenerator() {
+        private static final Pattern PACKAGE_PATTERN = Pattern.compile(".*\\.");
+
+        @NonNull
+        @Override
+        public String nameFor(@NonNull String className, @NonNull String methodName) {
+            var cn = replaceFirst(className, PACKAGE_PATTERN, "");
+            return cn + '.' + methodName;
+        }
+
+        @Override
+        public String toString() {
+            return "TxNameGenerator.LONG";
+        }
+    };
+
+    /**
+     * Prohibits starting transactions without explicitly setting transaction name via {@link TxManager#withName(String)}.
+     */
+    TxNameGenerator NONE = new TxNameGenerator() {
+        @NonNull
+        @Override
+        public String nameFor(@NonNull String className, @NonNull String methodName) {
+            throw new IllegalStateException("Transaction name must be explicitly set via TxManager.withName()");
+        }
+
+        @Override
+        public String toString() {
+            return "TxNameGenerator.NONE";
+        }
+    };
+
+    private static String replaceFirst(String input, Pattern regex, String replacement) {
+        return regex.matcher(input).replaceFirst(replacement);
+    }
+
+    private static String replaceAll(String input, Pattern regex, String replacement) {
+        return regex.matcher(input).replaceAll(replacement);
+    }
+}

--- a/repository/src/test/java/tech/ydb/yoj/repository/db/StdTxManagerTest.java
+++ b/repository/src/test/java/tech/ydb/yoj/repository/db/StdTxManagerTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -54,7 +55,9 @@ public class StdTxManagerTest {
 
     @Test
     public void testNotDbChildPackage_FromStackWalker_Auto_SkipCallerPackage() {
-        var name = new TestTxCaller(null, Set.of(TestTxCaller.class.getPackageName())).getTxName();
+        var name = new TestTxCaller(null)
+                .withSkipCallerPackages(Set.of(TestTxCaller.class.getPackageName()))
+                .getTxName();
         assertThat(name).isEqualTo("StdTxManTes#testNotDbChiPac_FroStaWal_Aut_SkiCalPac");
     }
 
@@ -68,6 +71,80 @@ public class StdTxManagerTest {
     @Test
     public void testNotDbPackage_FromStackWalker_User() {
         var name = new TestTxCaller("omg").getTxName();
+        assertThat(name).isEqualTo("omg");
+    }
+
+    // explicitly TxNameGenerator.LONG
+    @Test
+    public void testDbChildPackage_FromStackWalker_Auto_Long() {
+        var name = new TestDbTxCaller(null)
+                .withTxNameGenerator(TxNameGenerator.LONG)
+                .getTxName();
+        assertThat(name).isEqualTo("TestDbTxCaller.getTxName");
+    }
+
+    @Test
+    public void testNotDbChildPackage_FromStackWalker_Auto_Long() {
+        var name = new TestTxCaller(null)
+                .withTxNameGenerator(TxNameGenerator.LONG)
+                .getTxName();
+        assertThat(name).isEqualTo("TestTxCaller.getTxName");
+    }
+
+    @Test
+    public void testNotDbChildPackage_FromStackWalker_Auto_Long_SkipCallerPackage() {
+        var name = new TestTxCaller(null)
+                .withTxNameGenerator(TxNameGenerator.LONG)
+                .withSkipCallerPackages(Set.of(TestTxCaller.class.getPackageName()))
+                .getTxName();
+        assertThat(name).isEqualTo("StdTxManagerTest.testNotDbChildPackage_FromStackWalker_Auto_Long_SkipCallerPackage");
+    }
+
+    @Test
+    public void testNotDbPackage_Same_Long() {
+        var nameOld = new TestTxCaller(null).withTxNameGenerator(TxNameGenerator.LONG).getTxName();
+        var nameNew = new TestTxCaller(null).withTxNameGenerator(TxNameGenerator.LONG).getTxName();
+        assertThat(nameNew).isEqualTo(nameOld);
+    }
+
+    // explicitly TxNameGenerator.NONE
+    @Test
+    public void testDbChildPackage_FromStackWalker_ForceExplicitName_Auto_MustFail() {
+        assertThatIllegalStateException().isThrownBy(() ->
+                new TestDbTxCaller(null)
+                        .withTxNameGenerator(TxNameGenerator.NONE)
+                        .getTxName()
+        );
+    }
+
+    @Test
+    public void testNotDbChildPackage_FromStackWalker_ForceExplicitName_Auto_MustFail() {
+        assertThatIllegalStateException().isThrownBy(() ->
+                new TestTxCaller(null)
+                        .withTxNameGenerator(TxNameGenerator.NONE)
+                        .getTxName()
+        );
+    }
+
+    @Test
+    public void testNotDbChildPackage_FromStackWalker_SkipCallerPackage_ForceExplicitName_Auto_MustFail() {
+        assertThatIllegalStateException().isThrownBy(() ->
+                new TestTxCaller(null)
+                        .withTxNameGenerator(TxNameGenerator.NONE)
+                        .withSkipCallerPackages(Set.of(TestTxCaller.class.getPackageName()))
+                        .getTxName()
+        );
+    }
+
+    @Test
+    public void testNotDbPackage_ForceExplicitName_MustNotFail() {
+        var name = new TestTxCaller("omg").withTxNameGenerator(TxNameGenerator.NONE).getTxName();
+        assertThat(name).isEqualTo("omg");
+    }
+
+    @Test
+    public void testDbPackage_ForceExplicitName_MustNotFail() {
+        var name = new TestDbTxCaller("omg").withTxNameGenerator(TxNameGenerator.NONE).getTxName();
         assertThat(name).isEqualTo("omg");
     }
 

--- a/repository/src/test/java/tech/ydb/yoj/repository/testcaller/TestTxCaller.java
+++ b/repository/src/test/java/tech/ydb/yoj/repository/testcaller/TestTxCaller.java
@@ -1,33 +1,45 @@
 package tech.ydb.yoj.repository.testcaller;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.With;
 import tech.ydb.yoj.repository.db.IsolationLevel;
 import tech.ydb.yoj.repository.db.Repository;
 import tech.ydb.yoj.repository.db.RepositoryTransaction;
 import tech.ydb.yoj.repository.db.StdTxManager;
 import tech.ydb.yoj.repository.db.Tx;
+import tech.ydb.yoj.repository.db.TxNameGenerator;
 import tech.ydb.yoj.repository.db.TxOptions;
 import tech.ydb.yoj.repository.db.cache.TransactionLocal;
 import tech.ydb.yoj.repository.db.testcaller.TestDbTxCaller;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
+import static lombok.AccessLevel.PRIVATE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Part of {@link import tech.ydb.yoj.repository.db.StdTxManagerTest}.
+ * Part of {@link tech.ydb.yoj.repository.db.StdTxManagerTest}.
  * This is a copy of {@link TestDbTxCaller}
  * for testing calls from different packages.
  */
-@RequiredArgsConstructor
+@With
+@RequiredArgsConstructor(access = PRIVATE)
 public class TestTxCaller {
+    @Nullable
     private final String explicitName;
+
+    @NonNull
     private final Set<String> skipCallerPackages;
 
-    public TestTxCaller(String explicitName) {
-        this(explicitName, Set.of());
+    @NonNull
+    private final TxNameGenerator txNameGenerator;
+
+    public TestTxCaller(@Nullable String explicitName) {
+        this(explicitName, Set.of(), explicitName == null ? TxNameGenerator.SHORT : TxNameGenerator.NONE);
     }
 
     public String getTxName() {
@@ -36,7 +48,9 @@ public class TestTxCaller {
         when(rt.getTransactionLocal()).thenReturn(new TransactionLocal(TxOptions.create(IsolationLevel.SERIALIZABLE_READ_WRITE)));
         when(repo.startTransaction(any(TxOptions.class))).thenReturn(rt);
 
-        var tx = new StdTxManager(repo).withSkipCallerPackages(skipCallerPackages);
+        var tx = new StdTxManager(repo)
+                .withSkipCallerPackages(skipCallerPackages)
+                .withTxNameGenerator(txNameGenerator);
         if (explicitName != null) {
             tx = tx.withName(explicitName);
         }

--- a/util/src/main/java/tech/ydb/yoj/util/lang/CallStack.java
+++ b/util/src/main/java/tech/ydb/yoj/util/lang/CallStack.java
@@ -46,10 +46,14 @@ public final class CallStack {
             return findFrame();
         }
 
-        @SuppressWarnings("unchecked")
         public <T> T map(Function<StackFrame, T> mapper) {
+            return map(mapper, null);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> T map(Function<StackFrame, T> mapper, Object extraKey) {
             StackFrame frame = findFrame();
-            return (T) mapperCache.computeIfAbsent(new FrameKey(frame), __ -> mapper.apply(frame));
+            return (T) mapperCache.computeIfAbsent(new FrameKey(frame, extraKey), __ -> mapper.apply(frame));
         }
 
         private StackFrame findFrame() {
@@ -68,9 +72,9 @@ public final class CallStack {
         }
     }
 
-    private record FrameKey(String className, String methodName, int lineNumber) {
-        FrameKey(StackFrame frame) {
-            this(frame.getClassName(), frame.getMethodName(), frame.getLineNumber());
+    private record FrameKey(String className, String methodName, int lineNumber, Object extraKey) {
+        FrameKey(StackFrame frame, Object extraKey) {
+            this(frame.getClassName(), frame.getMethodName(), frame.getLineNumber(), extraKey);
         }
     }
 }


### PR DESCRIPTION
...introducing `TxNameGenerator.LONG` (for longer but more human-readable default tx names)
and `TxNameGenerator.NONE` (for forcing everyone to call `TxManager.withName(...)`)