### PR TITLE
Revert logic inversion in ModelField.validateValue exception handling

### DIFF
--- a/databind/src/main/java/tech/ydb/yoj/databind/expression/ModelField.java
+++ b/databind/src/main/java/tech/ydb/yoj/databind/expression/ModelField.java
@@ -64,8 +64,8 @@ public final class ModelField {
         ValidationResult validationResult = value.isValidValueOfType(field.getType(), fieldValueType);
         if (validationResult.invalid()) {
             throw userFieldPath != null
-                    ? validationResult.throwInternalError(userFieldPath)
-                    : validationResult.throwUserException(javaField.getPath());
+                    ? validationResult.throwUserException(userFieldPath)
+                    : validationResult.throwInternalError(javaField.getPath());
         }
         return value;
     }


### PR DESCRIPTION
This PR addresses a bug introduced in commit `d9b17fce4fde5ff3511b7017776ac255bd29c753` where the exception handling logic in ModelField.validateValue was inadvertently inverted.

**The Issue:**

Before: When `userFieldPath != null`, the method threw a `userException`; when `null`, it threw an `internalException`
After: The logic was reversed, causing incorrect exception types to be thrown

**This change is problematic because:**

- It breaks the expected behavior defined in `ValidationResult.throwUserException(String userFieldPath)` signature which explicitly expects a userFieldPath parameter
- It causes our test failures when upgrading from YOJ 2.5.15 to 2.6.26
- The current behavior contradicts the method's intended contract

**Impact:**
We discovered this issue when our test suite started failing after updating the YOJ dependency, indicating this regression affects real-world usage.

This commit restores the original exception handling logic to maintain backward compatibility and expected API behavior.