### PR TITLE
Strict schema operations exists

### DIFF
--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSchemaOperations.java
@@ -14,6 +14,7 @@ import tech.ydb.core.Status;
 import tech.ydb.core.grpc.GrpcTransport;
 import tech.ydb.proto.ValueProtos;
 import tech.ydb.scheme.SchemeClient;
+import tech.ydb.scheme.description.DescribePathResult;
 import tech.ydb.scheme.description.EntryType;
 import tech.ydb.scheme.description.ListDirectoryResult;
 import tech.ydb.table.Session;
@@ -443,7 +444,14 @@ public class YdbSchemaOperations implements AutoCloseable {
     }
 
     protected boolean hasPath(String path) {
-        return schemeClient.describePath(path).join().isSuccess();
+        Result<DescribePathResult> result = schemeClient.describePath(path).join();
+        if (result.isSuccess()) {
+            return true;
+        } else if (SCHEME_ERROR == result.getStatus().getCode() && YdbIssue.DEFAULT_ERROR.isContainedIn(result.getStatus().getIssues())) {
+            return false;
+        } else {
+            throw new YdbRepositoryException("Can't describe table '" + path + "': " + result);
+        }
     }
 
     @Override

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
@@ -48,6 +48,7 @@ import tech.ydb.topic.settings.WriterSettings;
 import tech.ydb.yoj.databind.schema.Column;
 import tech.ydb.yoj.databind.schema.GlobalIndex;
 import tech.ydb.yoj.databind.schema.ObjectSchema;
+import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.EntitySchema;
 import tech.ydb.yoj.repository.db.IsolationLevel;
 import tech.ydb.yoj.repository.db.QueryStatsMode;
@@ -69,6 +70,7 @@ import tech.ydb.yoj.repository.test.RepositoryTest;
 import tech.ydb.yoj.repository.test.entity.TestEntities;
 import tech.ydb.yoj.repository.test.sample.TestDb;
 import tech.ydb.yoj.repository.test.sample.TestDbImpl;
+import tech.ydb.yoj.repository.test.sample.model.Book;
 import tech.ydb.yoj.repository.test.sample.model.Bubble;
 import tech.ydb.yoj.repository.test.sample.model.ChangefeedEntity;
 import tech.ydb.yoj.repository.test.sample.model.IndexedEntity;
@@ -1350,6 +1352,16 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
         }
     }
 
+    @Test
+    public void schemaExistsForExistingEntity() {
+        assertThat(repository.schema(NonSerializableEntity.class).exists()).isTrue();
+    }
+
+    @Test
+    public void schemaNotExistsForMissingEntity() {
+        assertThat(repository.schema(MissingEntity.class).exists()).isFalse();
+    }
+
     private List<tech.ydb.topic.read.Message> readAll(TopicClient topicClient, String topicPath, String consumer, String reader) {
         var syncReader = topicClient.createSyncReader(ReaderSettings.newBuilder()
                 .setTopics(
@@ -1586,6 +1598,16 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
             void rollbackTransaction(tech.ydb.proto.query.YdbQuery.RollbackTransactionRequest request, io.grpc.stub.StreamObserver<tech.ydb.proto.query.YdbQuery.RollbackTransactionResponse> responseObserver);
 
             void executeQuery(tech.ydb.proto.query.YdbQuery.ExecuteQueryRequest request, io.grpc.stub.StreamObserver<tech.ydb.proto.query.YdbQuery.ExecuteQueryResponsePart> responseObserver);
+        }
+    }
+
+    @Value
+    private static class MissingEntity implements Entity<MissingEntity> {
+        Id id;
+
+        @Value
+        public static class Id implements Entity.Id<MissingEntity> {
+            String id;
         }
     }
 }


### PR DESCRIPTION
`tech.ydb.yoj.repository.db.SchemaOperations#exists` returns `false` for any non-successful result, including timeouts.

The method implementation uses `tech.ydb.yoj.repository.ydb.client.YdbSchemaOperations#hasPath`, which calls `tech.ydb.scheme.SchemeClient#describePath`, but doesn't check the full range of possible result statues/

This pr changes `hasPath` and `exists` behaviour to be fail-fast and as strict as possible:
- return `true` if and only if the `describePath` result has status `SUCCESS`
- return `false` if and only if the `describePath` result has status `SCHEME_ERROR` and issues list contains `DEFAULT_ERROR`
- throw exception on any other result