### PR TITLE
add StaticCredentials support to YdbRepository auth providers

### DIFF
--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepository.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepository.java
@@ -9,12 +9,13 @@ import lombok.NonNull;
 import lombok.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import tech.ydb.auth.AuthProvider;
+import tech.ydb.auth.AuthRpcProvider;
 import tech.ydb.auth.NopAuthProvider;
 import tech.ydb.core.grpc.BalancingSettings;
 import tech.ydb.core.grpc.GrpcTransport;
 import tech.ydb.core.grpc.GrpcTransportBuilder;
 import tech.ydb.core.impl.SingleChannelTransport;
+import tech.ydb.core.impl.auth.GrpcAuthRpc;
 import tech.ydb.table.SessionPoolStats;
 import tech.ydb.table.TableClient;
 import tech.ydb.yoj.repository.db.Entity;
@@ -71,16 +72,16 @@ public class YdbRepository implements Repository {
         this(config, NopAuthProvider.INSTANCE);
     }
 
-    public YdbRepository(@NonNull YdbConfig config, @NonNull AuthProvider authProvider) {
+    public YdbRepository(@NonNull YdbConfig config, @NonNull AuthRpcProvider<? super GrpcAuthRpc> authProvider) {
         this(config, authProvider, List.of());
     }
 
-    public YdbRepository(@NonNull YdbConfig config, @NonNull AuthProvider authProvider, List<ClientInterceptor> interceptors) {
+    public YdbRepository(@NonNull YdbConfig config, @NonNull AuthRpcProvider<? super GrpcAuthRpc> authProvider, List<ClientInterceptor> interceptors) {
         this(config, makeGrpcTransport(config, authProvider, interceptors));
     }
 
     public YdbRepository(@NonNull YdbConfig config, @NonNull Settings repositorySettings,
-                         @NonNull AuthProvider authProvider, List<ClientInterceptor> interceptors) {
+                         @NonNull AuthRpcProvider<? super GrpcAuthRpc> authProvider, List<ClientInterceptor> interceptors) {
         this(config, repositorySettings, makeGrpcTransport(config, authProvider, interceptors));
     }
 
@@ -106,7 +107,7 @@ public class YdbRepository implements Repository {
 
     private static GrpcTransport makeGrpcTransport(
             @NonNull YdbConfig config,
-            @NonNull AuthProvider authProvider,
+            @NonNull AuthRpcProvider<? super GrpcAuthRpc> authProvider,
             @NonNull List<ClientInterceptor> interceptors
     ) {
         boolean singleChannel = config.isUseSingleChannelTransport();
@@ -118,7 +119,7 @@ public class YdbRepository implements Repository {
 
     private static GrpcTransportBuilder makeGrpcTransportBuilder(
             @NonNull YdbConfig config,
-            @NonNull AuthProvider authProvider,
+            @NonNull AuthRpcProvider<? super GrpcAuthRpc> authProvider,
             @NonNull List<ClientInterceptor> interceptors
     ) {
         GrpcTransportBuilder transportBuilder;


### PR DESCRIPTION
This PR extends the authentication mechanism in YdbRepository to support a wider range of auth providers, most notably StaticCredentials.

**Changes:**
Refactor: Changed the constructor parameter type from AuthProvider (which extends AuthRpcProvider<Object>) to the more general AuthRpcProvider<? super GrpcAuthRpc>. This removes the unnecessary type restriction.
Feature: As a direct result of this change, YdbRepository can now natively accept a StaticCredentials instance (which implements AuthRpcProvider<GrpcAuthRpc>) as its auth provider.

**Why is this needed?**
The previous type signature (AuthProvider) was too specific and prevented the use of other compliant auth providers from the YDB SDK, such as StaticCredentials.

Backward Compatibility: 
This change is fully backward compatible. All existing code using AuthProvider will continue to work since AuthProvider is an AuthRpcProvider<Object>, which satisfies the new wildcard bound ? super GrpcAuthRpc