### PR TITLE
noticket: Add missing generic bound to ListRequest, *ListResponse and PageToken.{encode,decode}

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you wish to contribute to YOJ, see the [Notice to external contributors](CONT
 <dependency>
     <groupId>tech.ydb.yoj</groupId>
     <artifactId>yoj-bom</artifactId>
-    <version>2.6.51</version>
+    <version>2.6.52-SNAPSHOT</version>
     <type>pom</type>
     <scope>import</scope>
 </dependency>

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/GenericListResult.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/GenericListResult.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.repository.db.Entity;
+import tech.ydb.yoj.repository.db.EntitySchema;
 
 import java.util.Iterator;
 import java.util.List;
@@ -23,7 +24,7 @@ import static lombok.AccessLevel.PROTECTED;
  */
 @Getter
 @RequiredArgsConstructor(access = PROTECTED)
-public abstract class GenericListResult<T, R> implements Iterable<R> {
+public abstract class GenericListResult<T extends Entity<T>, R> implements Iterable<R> {
     /**
      * Result entries. This list might be empty.
      */
@@ -94,7 +95,7 @@ public abstract class GenericListResult<T, R> implements Iterable<R> {
     }
 
     @NonNull
-    public Schema<T> getRequestSchema() {
+    public EntitySchema<T> getRequestSchema() {
         return request.getSchema();
     }
 

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/InMemoryQueries.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/InMemoryQueries.java
@@ -14,7 +14,6 @@ import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.databind.schema.Schema.JavaField;
 import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.EntityIdSchema;
-import tech.ydb.yoj.repository.db.EntitySchema;
 import tech.ydb.yoj.repository.db.TableQueryImpl;
 import tech.ydb.yoj.util.function.StreamSupplier;
 
@@ -44,14 +43,11 @@ public final class InMemoryQueries {
 
     public static <T extends Entity<T>> ListResult<T> list(@NonNull StreamSupplier<T> streamSupplier,
                                                            @NonNull ListRequest<T> request) {
-        if (!(request.getSchema() instanceof EntitySchema<T> entitySchema)) {
-            throw new IllegalArgumentException("Expected ListRequest for an entity, but got a non-entity schema: " + request.getSchema());
-        }
         return ListResult.forPage(
                 request,
                 TableQueryImpl.find(
                         streamSupplier,
-                        entitySchema,
+                        request.getSchema(),
                         request.getFilter(),
                         request.getOrderBy(),
                         request.getPageSize() + 1,

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/ListResult.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/ListResult.java
@@ -10,9 +10,9 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 /**
- * Listing result page.
+ * Entity listing result page.
  */
-public final class ListResult<T> extends GenericListResult<T, T> implements Iterable<T> {
+public final class ListResult<T extends Entity<T>> extends GenericListResult<T, T> implements Iterable<T> {
     private ListResult(@NonNull List<T> entries, boolean lastPage, @NonNull ListRequest<T> request) {
         super(entries, request.getSchema(), lastPage, request);
     }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/ViewListResult.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/ViewListResult.java
@@ -3,7 +3,6 @@ package tech.ydb.yoj.repository.db.list;
 import lombok.NonNull;
 import tech.ydb.yoj.databind.schema.Schema;
 import tech.ydb.yoj.repository.db.Entity;
-import tech.ydb.yoj.repository.db.EntitySchema;
 import tech.ydb.yoj.repository.db.Table;
 import tech.ydb.yoj.repository.db.ViewSchema;
 
@@ -49,10 +48,7 @@ public final class ViewListResult<T extends Entity<T>, V extends Table.View> ext
             @NonNull ListRequest<T> request,
             @NonNull Class<V> viewClass
     ) {
-        if (!(request.getSchema() instanceof EntitySchema<?> entitySchema)) {
-            throw new IllegalArgumentException("Expected ListRequest for an entity, but got a non-entity schema: " + request.getSchema());
-        }
-        return entitySchema.getViewSchema(viewClass);
+        return request.getSchema().getViewSchema(viewClass);
     }
 
     public static final class ViewListResultBuilder<T extends Entity<T>, V extends Table.View> extends Builder<T, V, ViewListResult<T, V>> {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/token/EmptyPageToken.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/token/EmptyPageToken.java
@@ -1,6 +1,7 @@
 package tech.ydb.yoj.repository.db.list.token;
 
 import lombok.NonNull;
+import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.list.BadListingException.InvalidPageToken;
 import tech.ydb.yoj.repository.db.list.GenericListResult;
 import tech.ydb.yoj.repository.db.list.ListRequest;
@@ -16,14 +17,16 @@ public final class EmptyPageToken implements PageToken {
 
     @Nullable
     @Override
-    public <T, R> String encode(@NonNull GenericListResult<T, R> result) {
+    public <T extends Entity<T>, R> String encode(@NonNull GenericListResult<T, R> result) {
         return null;
     }
 
     @NonNull
     @Override
-    public <T> ListRequest.Builder<T> decode(@NonNull ListRequest.Builder<T> bldr,
-                                             @NonNull String token) throws InvalidPageToken {
+    public <T extends Entity<T>> ListRequest.Builder<T> decode(
+            @NonNull ListRequest.Builder<T> bldr,
+            @NonNull String token
+    ) throws InvalidPageToken {
         throw new InvalidPageToken();
     }
 }

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/token/FallbackPageToken.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/token/FallbackPageToken.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.list.BadListingException.InvalidPageToken;
 import tech.ydb.yoj.repository.db.list.GenericListResult;
 import tech.ydb.yoj.repository.db.list.ListRequest;
@@ -42,14 +43,16 @@ public class FallbackPageToken implements PageToken {
 
     @Nullable
     @Override
-    public <T, R> String encode(@NonNull GenericListResult<T, R> result) {
+    public <T extends Entity<T>, R> String encode(@NonNull GenericListResult<T, R> result) {
         return (encodeAsPrimary ? primary : fallback).encode(result);
     }
 
     @NonNull
     @Override
-    public <T> ListRequest.Builder<T> decode(@NonNull ListRequest.Builder<T> bldr,
-                                             @NonNull String token) throws InvalidPageToken {
+    public <T extends Entity<T>> ListRequest.Builder<T> decode(
+            @NonNull ListRequest.Builder<T> bldr,
+            @NonNull String token
+    ) throws InvalidPageToken {
         try {
             return primary.decode(bldr, token);
         } catch (InvalidPageToken primaryFailed) {

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/list/token/PageToken.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/list/token/PageToken.java
@@ -1,6 +1,7 @@
 package tech.ydb.yoj.repository.db.list.token;
 
 import lombok.NonNull;
+import tech.ydb.yoj.repository.db.Entity;
 import tech.ydb.yoj.repository.db.list.BadListingException.InvalidPageToken;
 import tech.ydb.yoj.repository.db.list.GenericListResult;
 import tech.ydb.yoj.repository.db.list.ListRequest;
@@ -29,7 +30,7 @@ public interface PageToken {
      * @return next page token or {@code null} if this is the last page of results
      */
     @Nullable
-    <T, R> String encode(@NonNull GenericListResult<T, R> result);
+    <T extends Entity<T>, R> String encode(@NonNull GenericListResult<T, R> result);
 
     /**
      * Decodes page token into listing request.<br>
@@ -42,6 +43,8 @@ public interface PageToken {
      * @return listing request builder for to the page encoded by the token
      * @throws InvalidPageToken page token is invalid
      */
-    @NonNull <T> ListRequest.Builder<T> decode(@NonNull ListRequest.Builder<T> bldr,
-                                               @NonNull String token) throws InvalidPageToken;
+    @NonNull <T extends Entity<T>> ListRequest.Builder<T> decode(
+            @NonNull ListRequest.Builder<T> bldr,
+            @NonNull String token
+    ) throws InvalidPageToken;
 }


### PR DESCRIPTION
These classes have always been intended only for use with `Entity`, but declarations technically allowed generic parameter to be anything as long as the user supplied the `Schema`.