### PR TITLE
#197: WIP WIP WIP Pass Db and Tx in transaction body lambda parameters WIP WIP WIP

### DIFF
--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/RepositoryTest.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import lombok.NonNull;
 import lombok.SneakyThrows;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import tech.ydb.yoj.databind.ByteArray;
 import tech.ydb.yoj.databind.expression.FieldValue;
@@ -20,6 +19,7 @@ import tech.ydb.yoj.repository.db.RecordEntity;
 import tech.ydb.yoj.repository.db.Repository;
 import tech.ydb.yoj.repository.db.RepositoryTransaction;
 import tech.ydb.yoj.repository.db.SchemaOperations;
+import tech.ydb.yoj.repository.db.ScopedTxManager;
 import tech.ydb.yoj.repository.db.StdTxManager;
 import tech.ydb.yoj.repository.db.Table;
 import tech.ydb.yoj.repository.db.Tx;
@@ -40,7 +40,6 @@ import tech.ydb.yoj.repository.db.readtable.ReadTableParams;
 import tech.ydb.yoj.repository.db.statement.Changeset;
 import tech.ydb.yoj.repository.test.entity.TestEntities;
 import tech.ydb.yoj.repository.test.sample.TestDb;
-import tech.ydb.yoj.repository.test.sample.TestDbImpl;
 import tech.ydb.yoj.repository.test.sample.TestEntityOperations;
 import tech.ydb.yoj.repository.test.sample.model.BadlyWrappedEntity;
 import tech.ydb.yoj.repository.test.sample.model.BadlyWrappedEntity.BadStringValueWrapper;
@@ -106,12 +105,15 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIterable;
+import static org.assertj.core.api.Assertions.assertThatList;
+import static org.assertj.core.api.Assertions.assertThatObject;
 import static org.assertj.core.api.Assertions.fail;
 import static tech.ydb.yoj.repository.db.EntityExpressions.newFilterBuilder;
 
 @SuppressWarnings("checkstyle:MethodCount")
 public abstract class RepositoryTest extends RepositoryTestSupport {
-    protected TestDb db;
+    protected ScopedTxManager<TestDb> tx;
 
     @Override
     protected Repository createRepository() {
@@ -121,12 +123,12 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Override
     public void setUp() {
         super.setUp();
-        this.db = new TestDbImpl<>(this.repository);
+        this.tx = new ScopedTxManager<>(this.repository, TestDb.class);
     }
 
     @Override
     public void tearDown() {
-        this.db = null;
+        this.tx = null;
         super.tearDown();
     }
 
@@ -202,13 +204,14 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void listWithQueryByNullableField() {
-        Project projectWithName1 = db.tx(() -> db.projects().save(new Project(new Project.Id("1"), "named_1")));
+        Project projectWithName1 = tx.call(db -> db.projects().save(new Project(new Project.Id("1"), "named_1")));
         assertThat(projectWithName1.getName()).isEqualTo("named_1");
-        Project projectWithName2 = db.tx(() -> db.projects().save(new Project(new Project.Id("2"), "named_2")));
+        Project projectWithName2 = tx.call(db -> db.projects().save(new Project(new Project.Id("2"), "named_2")));
         assertThat(projectWithName2.getName()).isEqualTo("named_2");
-        Project projectWithoutName = db.tx(() -> db.projects().save(new Project(new Project.Id("3"), null)));
+        Project projectWithoutName = tx.call(db -> db.projects().save(new Project(new Project.Id("3"), null)));
         assertThat(projectWithoutName.getName()).isNull();
-        assertThat(db.readOnly().run(() -> db.projects().findAll())).hasSize(3);
+        // FIXME
+        assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().findAll())).hasSize(3);
 
         FilterExpression<Project> eqNotNullExp = newFilterBuilder(Project.class)
                 .where("name").eq("named_1")
@@ -233,32 +236,32 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void simpleCrudInDifferentTx() {
-        Project p1 = db.tx(() -> {
+        Project p1 = tx.call(db -> {
             Project p = new Project(new Project.Id("1"), "named");
             db.projects().save(p);
             return p;
         });
 
-        Project p2 = db.tx(() -> db.projects().find(new Project.Id("1")));
+        Project p2 = tx.call(db -> db.projects().find(new Project.Id("1")));
         assertThat(p2).isEqualTo(p1);
 
-        Project p3 = db.tx(() -> {
+        Project p3 = tx.call(db -> {
             Project p = new Project(new Project.Id("1"), "renamed");
             db.projects().save(p);
             return p;
         });
-        Project p4 = db.tx(() -> db.projects().find(new Project.Id("1")));
+        Project p4 = tx.call(db -> db.projects().find(new Project.Id("1")));
         assertThat(p4).isEqualTo(p3);
 
-        db.tx(() -> db.projects().delete(new Project.Id("1")));
-        Project p5 = db.tx(() -> db.projects().find(new Project.Id("1")));
+        tx.run(db -> db.projects().delete(new Project.Id("1")));
+        Project p5 = tx.call(db -> db.projects().find(new Project.Id("1")));
         assertThat(p5).isNull();
     }
 
     @Test
     public void deferAfterCommitDontRunInDryRun() {
-        db.withDryRun(true).tx(
-                () -> Tx.Current.get().defer(
+        tx.withDryRun(true).run((_1, txControl) ->
+                txControl.defer(
                         () -> fail("defer after commit musn't call in dry run")
                 )
         );
@@ -266,8 +269,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void deferNotInTxContext() {
-        db.tx(
-                () -> Tx.Current.get().defer(
+        tx.run((_1, txControl) ->
+                txControl.defer(
                         () -> assertThat(Tx.Current.exists())
                                 .withFailMessage("defer must not run in tx context")
                                 .isFalse()
@@ -277,8 +280,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void deferFinallyDontRunInDryRun() {
-        db.withDryRun(true).tx(
-                () -> Tx.Current.get().deferFinally(
+        tx.withDryRun(true).run((_1, txControl) ->
+                txControl.deferFinally(
                         () -> fail("defer after commit musn't be called in dry-run mode")
                 )
         );
@@ -287,15 +290,15 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void deferFinallyCommit() {
         AtomicInteger executions = new AtomicInteger();
-        db.tx(() -> Tx.Current.get().deferFinally(executions::incrementAndGet));
+        tx.run((_1, txControl) -> txControl.deferFinally(executions::incrementAndGet));
         assertThat(executions).hasValue(1);
     }
 
     @Test
     public void deferFinallyRollback() {
         AtomicInteger executions = new AtomicInteger();
-        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> db.tx(() -> {
-            Tx.Current.get().deferFinally(executions::incrementAndGet);
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> tx.run((_1, txControl) -> {
+            txControl.deferFinally(executions::incrementAndGet);
             throw new RuntimeException();
         }));
         assertThat(executions).hasValue(1);
@@ -304,7 +307,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void deferFinallyRollbackRetryable() {
         AtomicInteger executions = new AtomicInteger();
-        assertThatExceptionOfType(UnavailableException.class).isThrownBy(() -> db.tx(() -> {
+        assertThatExceptionOfType(UnavailableException.class).isThrownBy(() -> tx.call(db -> {
             Tx.Current.get().deferFinally(executions::incrementAndGet);
             throw new OptimisticLockException("");
         }));
@@ -313,7 +316,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void deferFinallyNotInTxContext() {
-        db.tx(() -> Tx.Current.get().deferFinally(() ->
+        tx.run((_1, txControl) -> txControl.deferFinally(() ->
                 assertThat(Tx.Current.exists())
                         .withFailMessage("deferFinally must not be in a tx context")
                         .isFalse()
@@ -322,8 +325,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void deferFinallyRollbackNotInTxContext() {
-        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> db.tx(() -> {
-            Tx.Current.get().deferFinally(() ->
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> tx.run((_1, txControl) -> {
+            txControl.deferFinally(() ->
                     assertThat(Tx.Current.exists())
                             .withFailMessage("deferFinally must not be in a tx context")
                             .isFalse()
@@ -334,24 +337,24 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void findAll() {
-        List<Project> all = db.tx(() -> db.projects().findAll());
+        List<Project> all = tx.call(db -> db.projects().findAll());
         assertThat(all).isEmpty();
 
-        Project p1 = db.tx(() -> {
+        Project p1 = tx.call(db -> {
             Project p = new Project(new Project.Id("1"), "p1");
             db.projects().save(p);
             return p;
         });
-        List<Project> all1 = db.tx(() -> db.projects().findAll());
+        List<Project> all1 = tx.call(db -> db.projects().findAll());
         assertThat(all1).hasSize(1);
         assertThat(all1.get(0)).isEqualTo(p1);
 
-        db.tx(() -> db.projects().save(new Project(new Project.Id("2"), "p2")));
-        List<Project> all2 = db.tx(() -> db.projects().findAll());
+        tx.call(db -> db.projects().save(new Project(new Project.Id("2"), "p2")));
+        List<Project> all2 = tx.call(db -> db.projects().findAll());
         assertThat(all2).hasSize(2);
 
-        db.tx(() -> db.projects().deleteAll());
-        List<Project> all3 = db.tx(() -> db.projects().findAll());
+        tx.run(db -> db.projects().deleteAll());
+        List<Project> all3 = tx.call(db -> db.projects().findAll());
         assertThat(all3).isEmpty();
     }
 
@@ -359,18 +362,18 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void streamAll() {
         for (int i = 1; i < 5; i++) {
             Project p = new Project(new Project.Id(String.valueOf(i)), "");
-            db.tx(() -> db.projects().save(p));
-            assertThat(db.tx(() -> db.projects().streamAll(2).collect(toList())))
+            tx.call(db -> db.projects().save(p));
+            assertThat(tx.<List<Project>>call(db -> db.projects().streamAll(2).collect(toList())))
                     .hasSize(i);
         }
 
-        assertThat(db.tx(() -> db.projects().streamAll(2).limit(1).collect(toList())))
+        assertThat(tx.<List<Project>>call(db -> db.projects().streamAll(2).limit(1).collect(toList())))
                 .hasSize(1);
 
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.tx(() -> db.projects().streamAll(0)));
+                .isThrownBy(() -> tx.run(db -> db.projects().streamAll(0)));
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.tx(() -> db.projects().streamAll(5001)));
+                .isThrownBy(() -> tx.run(db -> db.projects().streamAll(5001)));
     }
 
     private static <ID extends Entity.Id<?>> ReadTableParams<ID> defaultReadTableParamsNonLegacy() {
@@ -383,14 +386,16 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void readTable() {
-        assertThat(db.readOnly().run(() -> db.projects().readTable(defaultReadTableParamsNonLegacy()).count())).isEqualTo(0);
+        // FIXME
+        assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTable(defaultReadTableParamsNonLegacy()).count())).isEqualTo(0);
 
         List<Project> expectedProjects = new ArrayList<>();
         for (int i = 1; i <= 9; ++i) {
             Project p = new Project(new Project.Id(String.valueOf(i)), "project-" + i);
             expectedProjects.add(p);
-            db.tx(() -> db.projects().save(p));
-            assertThat(db.readOnly().run(() -> db.projects().readTable(defaultReadTableParamsNonLegacy()).count()))
+            tx.call(db -> db.projects().save(p));
+            // FIXME
+            assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTable(defaultReadTableParamsNonLegacy()).count()))
                     .isEqualTo(i);
         }
 
@@ -404,7 +409,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .rowLimit(5)
                 .build();
         assertThat(
-                db.readOnly().run(() -> db.projects().readTable(readFrom)
+                // FIXME
+                tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTable(readFrom)
                         .map(p -> p.getId().getValue())
                         .collect(Collectors.toList()))
         ).isEqualTo(
@@ -413,7 +419,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         .collect(Collectors.toList())
         );
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.readOnly().run(() -> db.projects().readTable(readFromUnordered)));
+                // FIXME
+                .isThrownBy(() -> tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTable(readFromUnordered)));
         ReadTableParams<Project.Id> readFromTo = RepositoryTest.<Project.Id>buildReadTableParamsNonLegacy()
                 .fromKeyInclusive(expectedProjects.get(3).getId())
                 .toKey(expectedProjects.get(7).getId())
@@ -424,7 +431,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .toKey(expectedProjects.get(7).getId())
                 .build();
         assertThat(
-                db.readOnly().run(() -> db.projects().readTable(readFromTo)
+                // FIXME
+                tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTable(readFromTo)
                         .map(p -> p.getId().getValue())
                         .collect(Collectors.toList()))
         ).isEqualTo(
@@ -433,22 +441,25 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         .collect(Collectors.toList())
         );
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.readOnly().run(() -> db.projects().readTable(readFromToUnordered)));
+                // FIXME
+                .isThrownBy(() -> tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTable(readFromToUnordered)));
         assertThatExceptionOfType(IllegalTransactionIsolationLevelException.class)
-                .isThrownBy(() -> db.tx(() -> db.projects().readTable(defaultReadTableParamsNonLegacy()).count()));
+                .isThrownBy(() -> tx.call(db -> db.projects().readTable(defaultReadTableParamsNonLegacy()).count()));
     }
 
     @Test
     public void readTableIds() {
-        assertThat(db.readOnly().run(() -> db.projects().readTableIds(defaultReadTableParamsNonLegacy()).count()))
+        // FIXME
+        assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTableIds(defaultReadTableParamsNonLegacy()).count()))
                 .isEqualTo(0);
 
         List<Project.Id> expectedProjectIds = new ArrayList<>();
         for (int i = 1; i <= 9; ++i) {
             Project p = new Project(new Project.Id(String.valueOf(i)), "project-" + i);
             expectedProjectIds.add(p.getId());
-            db.tx(() -> db.projects().save(p));
-            assertThat(db.readOnly().run(() -> db.projects().readTableIds(defaultReadTableParamsNonLegacy()).count()))
+            tx.call(db -> db.projects().save(p));
+            // FIXME
+            assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTableIds(defaultReadTableParamsNonLegacy()).count()))
                     .isEqualTo(i);
         }
 
@@ -462,7 +473,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .rowLimit(5)
                 .build();
         assertThat(
-                db.readOnly().run(() -> db.projects().readTableIds(readFrom)
+                // FIXME
+                tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTableIds(readFrom)
                         .map(Project.Id::getValue)
                         .collect(Collectors.toList()))
         ).isEqualTo(
@@ -471,7 +483,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         .collect(Collectors.toList())
         );
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.readOnly().run(() -> db.projects().readTableIds(readFromUnordered)));
+                // FIXME
+                .isThrownBy(() -> tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTableIds(readFromUnordered)));
         ReadTableParams<Project.Id> readFromTo = RepositoryTest.<Project.Id>buildReadTableParamsNonLegacy()
                 .fromKeyInclusive(expectedProjectIds.get(3))
                 .toKey(expectedProjectIds.get(7))
@@ -482,7 +495,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .toKey(expectedProjectIds.get(7))
                 .build();
         assertThat(
-                db.readOnly().run(() -> db.projects().readTableIds(readFromTo)
+                // FIXME
+                tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTableIds(readFromTo)
                         .map(Project.Id::getValue)
                         .collect(Collectors.toList()))
         ).isEqualTo(
@@ -491,14 +505,16 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         .collect(Collectors.toList())
         );
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.readOnly().run(() -> db.projects().readTableIds(readFromToUnordered)));
+                // FIXME
+                .isThrownBy(() -> tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().readTableIds(readFromToUnordered)));
         assertThatExceptionOfType(IllegalTransactionIsolationLevelException.class)
-                .isThrownBy(() -> db.tx(() -> db.projects().readTableIds(defaultReadTableParamsNonLegacy()).count()));
+                .isThrownBy(() -> tx.call(db -> db.projects().readTableIds(defaultReadTableParamsNonLegacy()).count()));
     }
 
     @Test
     public void readTableViews() {
-        assertThat(db.readOnly().run(() -> db.typeFreaks().readTableIds(defaultReadTableParamsNonLegacy()).count()))
+        // FIXME
+        assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).typeFreaks().readTableIds(defaultReadTableParamsNonLegacy()).count()))
                 .isEqualTo(0);
 
         List<TypeFreak.View> expectedViews = new ArrayList<>();
@@ -506,12 +522,13 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         for (int i = 0; i < 100; i++) {
             TypeFreak tf = newTypeFreak(i, "AAA" + (i + 1), "bbb");
 
-            db.tx(() -> db.typeFreaks().save(tf));
+            tx.call(db -> db.typeFreaks().save(tf));
             savedCount++;
 
             if (i < 50) {
                 expectedViews.add(new TypeFreak.View(tf.getId(), tf.getEmbedded()));
-                assertThat(db.readOnly().run(() -> db.typeFreaks()
+                // FIXME
+                assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).typeFreaks()
                         .readTable(TypeFreak.View.class, defaultReadTableParamsNonLegacy()).count())).isEqualTo(savedCount);
             }
         }
@@ -521,7 +538,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .rowLimit(expectedViews.size())
                 .ordered()
                 .build();
-        assertThat(db.readOnly().run(() -> db.typeFreaks().readTable(TypeFreak.View.class, readFrom).collect(toList())))
+        // FIXME
+        assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).typeFreaks().readTable(TypeFreak.View.class, readFrom).collect(toList())))
                 .isEqualTo(expectedViews);
 
         ReadTableParams<TypeFreak.Id> readFromTo = RepositoryTest.<TypeFreak.Id>buildReadTableParamsNonLegacy()
@@ -529,11 +547,12 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .toKeyInclusive(expectedViews.get(expectedViews.size() - 1).getId())
                 .ordered()
                 .build();
-        assertThat(db.readOnly().run(() -> db.typeFreaks().readTable(TypeFreak.View.class, readFromTo).collect(toList())))
+        // FIXME
+        assertThat(tx.readOnly().run(() -> BaseDb.current(TestDb.class).typeFreaks().readTable(TypeFreak.View.class, readFromTo).collect(toList())))
                 .isEqualTo(expectedViews);
 
         assertThatExceptionOfType(IllegalTransactionIsolationLevelException.class)
-                .isThrownBy(() -> db.tx(() -> db.typeFreaks().readTableIds(defaultReadTableParamsNonLegacy()).count()));
+                .isThrownBy(() -> tx.call(db -> db.typeFreaks().readTableIds(defaultReadTableParamsNonLegacy()).count()));
     }
 
     @Test
@@ -541,66 +560,67 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Project.Id id1 = new Project.Id("id1");
         Project.Id id2 = new Project.Id("id2");
 
-        RepositoryTransaction tx = repository.startTransaction(
+        RepositoryTransaction repositoryTransaction = repository.startTransaction(
                 TxOptions.create(IsolationLevel.SERIALIZABLE_READ_WRITE)
                         .withImmediateWrites(true)
                         .withFirstLevelCache(false)
         );
 
-        tx.table(Project.class).find(id2);
+        repositoryTransaction.table(Project.class).find(id2);
 
-        db.tx(() -> db.projects().save(new Project(id2, "name2")));
+        tx.run(db -> db.projects().save(new Project(id2, "name2")));
 
-        tx.table(Project.class).save(new Project(id1, "name1")); // make tx available for TLI
+        repositoryTransaction.table(Project.class).save(new Project(id1, "name1")); // make tx available for TLI
 
         assertThatExceptionOfType(OptimisticLockException.class)
-                .isThrownBy(() -> tx.table(Project.class).find(id2));
+                .isThrownBy(() -> repositoryTransaction.table(Project.class).find(id2));
 
         try {
-            tx.commit();
+            repositoryTransaction.commit();
         } catch (IllegalStateException ignore) {
             // Some implementations throw, some don't
         }
 
-        tx.rollback(); // YOJ-tx rollback is possible. session.rollbackCommit() won't execute
+        repositoryTransaction.rollback(); // YOJ-tx rollback is possible. session.rollbackCommit() won't execute
     }
 
     @Test
     public void writeDontProduceTLI() {
         Project.Id id = new Project.Id("id");
 
-        db.tx(() -> db.projects().save(new Project(id, "name")));
+        tx.call(db -> db.projects().save(new Project(id, "name")));
 
-        RepositoryTransaction tx = repository.startTransaction(
+        RepositoryTransaction repositoryTransaction = repository.startTransaction(
                 TxOptions.create(IsolationLevel.SERIALIZABLE_READ_WRITE)
                         .withImmediateWrites(true)
                         .withFirstLevelCache(false)
         );
 
-        tx.table(Project.class).find(id);
+        repositoryTransaction.table(Project.class).find(id);
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().find(id);
             db.projects().save(new Project(id, "name2"));
         });
 
         // write don't produce TLI
-        tx.table(Project.class).save(new Project(id, "name3"));
+        repositoryTransaction.table(Project.class).save(new Project(id, "name3"));
 
         assertThatExceptionOfType(OptimisticLockException.class)
-                .isThrownBy(tx::commit);
+                .isThrownBy(repositoryTransaction::commit);
     }
 
     @Test
     public void spliteratorDoubleTryAdvance() {
-        db.tx(() -> {
+        tx.run(db -> {
             for (int i = 0; i < 100; i++) {
                 db.projects().save(new Project(new Project.Id(String.valueOf(i)), ""));
             }
         });
 
-        db.readOnly().run(() -> {
-            Spliterator<Project> spliterator = db.projects().readTable(defaultReadTableParamsNonLegacy()).spliterator();
+        tx.readOnly().run(() -> {
+            //FIXME
+            Spliterator<Project> spliterator = BaseDb.current(TestDb.class).projects().readTable(defaultReadTableParamsNonLegacy()).spliterator();
 
             // this loop calls tryAdvance() on spliterator one time after tryAdvance() says false
             while (true) {
@@ -612,8 +632,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         });
 
         // one more example
-        db.readOnly().run(() -> {
-            Stream<Project> stream = db.projects().readTable(defaultReadTableParamsNonLegacy());
+        tx.readOnly().run(() -> {
+            // FIXME
+            Stream<Project> stream = BaseDb.current(TestDb.class).projects().readTable(defaultReadTableParamsNonLegacy());
 
             Stream<List<Project>> stream2 = StreamSupport.stream(
                     // With this line steam calls tryAdvance() on spliterator one time after tryAdvance() says false
@@ -631,39 +652,37 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Project.Id id1 = new Project.Id("id1");
         Project.Id id2 = new Project.Id("id2");
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().save(new Project(id1, "name"));
             db.projects().save(new Project(id2, "name"));
         });
 
-        RepositoryTransaction tx = repository.startTransaction(
+        RepositoryTransaction repositoryTransaction = repository.startTransaction(
                 TxOptions.create(IsolationLevel.SERIALIZABLE_READ_WRITE)
                         .withImmediateWrites(true)
                         .withFirstLevelCache(false)
         );
 
-        tx.table(Project.class).save(new Project(new Project.Id("id3"), "name")); // make tx available for TLI
+        repositoryTransaction.table(Project.class).save(new Project(new Project.Id("id3"), "name")); // make tx available for TLI
 
-        tx.table(Project.class).find(id1);
-        tx.table(Project.class).find(id2);
+        repositoryTransaction.table(Project.class).find(id1);
+        repositoryTransaction.table(Project.class).find(id2);
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().find(id2);
             db.projects().save(new Project(id2, "name2"));
         });
 
         assertThatExceptionOfType(OptimisticLockException.class)
-                .isThrownBy(() -> tx.table(Project.class).find(id1));
+                .isThrownBy(() -> repositoryTransaction.table(Project.class).find(id1));
     }
 
     @Test
     public void streamAllWithPartitioning() {
-        db.tx(() -> {
-            db.complexes().insert(new Complex(new Complex.Id(0, 0L, "0", Complex.Status.OK)));
-        });
+        tx.run(db -> db.complexes().insert(new Complex(new Id(0, 0L, "0", Complex.Status.OK))));
 
-        assertThat(db.tx(() -> {
-            ArrayList<Object> found = new ArrayList<>();
+        assertThatList(tx.call(db -> {
+            List<Object> found = new ArrayList<>();
             Iterators.partition(
                             db.complexes()
                                     .streamAll(100)
@@ -678,145 +697,122 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void viewStreamAll() {
         for (int i = 1; i < 5; i++) {
             Book b = new Book(new Book.Id(String.valueOf(i)), i, "title-" + i, List.of());
-            db.tx(() -> db.table(Book.class).save(b));
-            assertThat(db.tx(() -> db.table(Book.class).streamAll(Book.TitleViewId.class, 2).collect(toList())))
+            tx.run(db -> db.table(Book.class).save(b));
+            assertThatList(tx.call(db -> db.table(Book.class).streamAll(Book.TitleViewId.class, 2).collect(toList())))
                     .hasSize(i);
         }
-        db.tx(() -> db.table(Book.class)
+        tx.run(db -> db.table(Book.class)
                 .streamAll(Book.TitleViewId.class, 100)
                 .forEach(titleView -> assertThat(titleView.getTitle()).isNotBlank()));
 
-        assertThat(db.tx(() -> db.table(Book.class).streamAll(Book.TitleViewId.class, 2)
+        assertThatList(tx.call(db -> db.table(Book.class).streamAll(Book.TitleViewId.class, 2)
                 .limit(1).collect(toList())))
                 .hasSize(1);
 
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.tx(() -> db.table(Book.class).streamAll(Book.TitleViewId.class, 0)));
+                .isThrownBy(() -> tx.call(db -> db.table(Book.class).streamAll(Book.TitleViewId.class, 0)));
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> db.tx(() -> db.table(Book.class).streamAll(Book.TitleViewId.class, 5001)));
+                .isThrownBy(() -> tx.call(db -> db.table(Book.class).streamAll(Book.TitleViewId.class, 5001)));
     }
 
     @Test
     public void streamAllComposite() {
-        db.tx(this::makeComplexes);
-        assertThat(
-                db.tx(() -> db.complexes().streamAll(2).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().findAll())
-        );
+        tx.run(this::makeComplexes);
+        tx.run(db -> assertThat(db.complexes().streamAll(2))
+                .containsExactlyElementsOf(db.complexes().findAll()));
     }
 
     @Test
     public void streamEmpty() {
-        db.tx(() -> assertThat(db.complexes().streamAll(2)).isEmpty());
+        tx.run(db -> assertThat(db.complexes().streamAll(2)).isEmpty());
     }
 
     @Test
     public void streamPartial() {
-        db.tx(this::makeComplexes);
-        assertThat(
-                db.tx(() -> db.complexes().streamPartial(new Complex.Id(0, 0L, "aaa", Complex.Status.OK), 2).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", Complex.Status.OK))))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartial(new Complex.Id(0, 0L, "aaa", null), 2).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", null))))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartial(new Complex.Id(0, 0L, null, null), 2).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, 0L, null, null))))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartial(new Complex.Id(0, null, null, null), 2).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, null, null, null))))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartial(new Complex.Id(null, null, null, null), 2).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(null, null, null, null))))
-        );
+        tx.run(this::makeComplexes);
+        tx.run(db -> {
+            assertThat(db.complexes().streamPartial(new Complex.Id(0, 0L, "aaa", Complex.Status.OK), 2))
+                    .containsExactlyElementsOf(db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", Complex.Status.OK))));
+            assertThat(db.complexes().streamPartial(new Complex.Id(0, 0L, "aaa", null), 2))
+                    .containsExactlyElementsOf(db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", null))));
+            assertThat(db.complexes().streamPartial(new Complex.Id(0, 0L, null, null), 2))
+                    .containsExactlyElementsOf(db.complexes().find(Range.create(new Complex.Id(0, 0L, null, null))));
+            assertThat(db.complexes().streamPartial(new Complex.Id(0, null, null, null), 2))
+                    .containsExactlyElementsOf(db.complexes().find(Range.create(new Complex.Id(0, null, null, null))));
+            assertThat(db.complexes().streamPartial(new Complex.Id(null, null, null, null), 2))
+                    .containsExactlyElementsOf(db.complexes().find(Range.create(new Complex.Id(null, null, null, null))));
+        });
     }
 
     @Test
     public void streamPartialWithPartitioning() {
-        db.tx(() -> {
-            db.complexes().insert(new Complex(new Complex.Id(0, 0L, "0", Complex.Status.OK)));
-        });
+        tx.run(db -> db.complexes().insert(new Complex(new Complex.Id(0, 0L, "0", Complex.Status.OK))));
 
-        assertThat(
-                db.tx(() -> db.complexes().streamPartial(new Complex.Id(0, null, null, null), 100).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(null, null, null, null))))
-        );
+        tx.run(db -> {
+            assertThat(db.complexes().streamPartial(new Complex.Id(0, null, null, null), 100))
+                    .containsExactlyElementsOf(db.complexes().find(Range.create(new Complex.Id(null, null, null, null))));
 
-
-        assertThat(db.tx(() -> {
-            ArrayList<Object> found = new ArrayList<>();
+            List<Object> found = new ArrayList<>();
             Iterators.partition(
-                            db.complexes()
-                                    .streamPartial(new Complex.Id(0, null, null, null), 100)
-                                    .map(Complex::getId)
-                                    .iterator(), 100)
-                    .forEachRemaining(found::addAll);
-            return found;
-        })).hasSize(1);
+                    db.complexes()
+                            .streamPartial(new Complex.Id(0, null, null, null), 100)
+                            .map(Complex::getId)
+                            .iterator(),
+                    100
+            ).forEachRemaining(found::addAll);
+            assertThat(found).hasSize(1);
+        });
     }
 
     @Test
     public void streamPartialIds() {
-        db.tx(this::makeComplexes);
-        assertThat(
-                db.tx(() -> db.complexes().streamPartialIds(new Complex.Id(0, 0L, "aaa", Complex.Status.OK), 100).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", Complex.Status.OK)))
-                        .stream().map(Complex::getId).collect(toList()))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartialIds(new Complex.Id(0, 0L, "aaa", null), 100).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", null)))
-                        .stream().map(Complex::getId).collect(toList()))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartialIds(new Complex.Id(0, 0L, null, null), 100).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, 0L, null, null)))
-                        .stream().map(Complex::getId).collect(toList()))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartialIds(new Complex.Id(0, null, null, null), 100).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(0, null, null, null)))
-                        .stream().map(Complex::getId).collect(toList()))
-        );
-        assertThat(
-                db.tx(() -> db.complexes().streamPartialIds(new Complex.Id(null, null, null, null), 100).collect(toList()))
-        ).isEqualTo(
-                db.tx(() -> db.complexes().find(Range.create(new Complex.Id(null, null, null, null)))
-                        .stream().map(Complex::getId).collect(toList()))
-        );
+        tx.run(this::makeComplexes);
+
+        tx.run(db -> {
+            assertThat(db.complexes().streamPartialIds(new Complex.Id(0, 0L, "aaa", Complex.Status.OK), 100))
+                    .containsExactlyElementsOf(
+                            db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", Complex.Status.OK)))
+                                    .stream().map(Complex::getId).toList()
+                    );
+            assertThat(db.complexes().streamPartialIds(new Complex.Id(0, 0L, "aaa", null), 100))
+                    .containsExactlyElementsOf(
+                            db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", null)))
+                                    .stream().map(Complex::getId).toList()
+                    );
+            assertThat(db.complexes().streamPartialIds(new Complex.Id(0, 0L, null, null), 100))
+                    .containsExactlyElementsOf(
+                            db.complexes().find(Range.create(new Complex.Id(0, 0L, null, null)))
+                                    .stream().map(Complex::getId).toList()
+                    );
+            assertThat(db.complexes().streamPartialIds(new Complex.Id(0, null, null, null), 100))
+                    .containsExactlyElementsOf(
+                            db.complexes().find(Range.create(new Complex.Id(0, null, null, null)))
+                                    .stream().map(Complex::getId).toList()
+                    );
+            assertThat(db.complexes().streamPartialIds(new Complex.Id(null, null, null, null), 100))
+                    .containsExactlyElementsOf(
+                            db.complexes().find(Range.create(new Complex.Id(null, null, null, null)))
+                                    .stream().map(Complex::getId).toList()
+                    );
+        });
     }
 
     @Test
     public void countAll() {
-        long allSize = db.tx(() -> db.projects().countAll());
+        long allSize = tx.call(db -> db.projects().countAll());
         assertThat(allSize).isEqualTo(0L);
 
-        db.tx(() -> db.projects().save(new Project(new Project.Id("1"), "p1")));
+        tx.run(db -> db.projects().save(new Project(new Project.Id("1"), "p1")));
 
-        long all1 = db.tx(() -> db.projects().countAll());
+        long all1 = tx.call(db -> db.projects().countAll());
         assertThat(all1).isEqualTo(1L);
 
-        db.tx(() -> db.projects().save(new Project(new Project.Id("2"), "p2")));
-        long all2 = db.tx(() -> db.projects().countAll());
+        tx.run(db -> db.projects().save(new Project(new Project.Id("2"), "p2")));
+        long all2 = tx.call(db -> db.projects().countAll());
         assertThat(all2).isEqualTo(2L);
 
-        db.tx(() -> db.projects().deleteAll());
-        long all3 = db.tx(() -> db.projects().countAll());
+        tx.run(db -> db.projects().deleteAll());
+        long all3 = tx.call(db -> db.projects().countAll());
         assertThat(all3).isEqualTo(0L);
     }
 
@@ -825,9 +821,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         List<Project> projects = IntStream.range(100, 200)
                 .mapToObj(i -> new Project(new Project.Id("proj" + i), null))
                 .collect(toList());
-        db.tx(() -> db.projects().insertAll(projects));
+        tx.run(db -> db.projects().insertAll(projects));
 
-        db.tx(() -> {
+        tx.run(db -> {
             List<Project> projectsViaStreamAllIterator = new ArrayList<>();
             Iterator<Project> iterator = db.projects().streamAll(1_000).iterator();
             while (iterator.hasNext()) {
@@ -842,9 +838,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         List<Project> projects = IntStream.range(200, 300)
                 .mapToObj(i -> new Project(new Project.Id("p" + i), null))
                 .collect(toList());
-        db.tx(() -> db.projects().insertAll(projects));
+        tx.run(db -> db.projects().insertAll(projects));
 
-        db.tx(() -> {
+        tx.run(db -> {
             List<Project> projectsViaStreamAllIterator = new ArrayList<>();
             Iterator<Project> iterator = db.projects().streamAll(13).iterator();
             while (iterator.hasNext()) {
@@ -856,8 +852,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void findRange() {
-        db.tx(this::makeComplexes);
-        db.tx(() -> {
+        tx.run(this::makeComplexes);
+        tx.run(db -> {
             assertThat(db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", Complex.Status.OK)))).hasSize(1);
             assertThat(db.complexes().find(Range.create(new Complex.Id(0, 0L, "aaa", null)))).hasSize(2);
             assertThat(db.complexes().find(Range.create(new Complex.Id(0, 0L, null, null)))).hasSize(6);
@@ -902,7 +898,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         return repository.startTransaction(TxOptions.create(IsolationLevel.SERIALIZABLE_READ_WRITE));
     }
 
-    protected void makeComplexes() {
+    private void makeComplexes(TestDb db) {
         for (int a = 0; a < 3; a++) {
             for (long b = 0; b < 3; b++) {
                 for (String c : List.of("aaa", "aab", "bbb")) {
@@ -916,8 +912,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void findInCompleteIdAllFromCache() {
-        db.tx(this::makeComplexes);
-        db.tx(() -> {
+        tx.run(this::makeComplexes);
+        tx.run(db -> {
             var idsToFetch = Set.of(
                     new Id(0, 0L, "aaa", Complex.Status.OK),
                     new Id(0, 0L, "aaa", Complex.Status.FAIL)
@@ -953,8 +949,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var idUnexistent = new Id(0, -1L, "aaa", Complex.Status.OK);
         var idUnexistentMarkedEmptyInCache = new Id(0, -2L, "aaa", Complex.Status.OK);
 
-        db.tx(this::makeComplexes);
-        db.tx(() -> {
+        tx.run(this::makeComplexes);
+        tx.run(db -> {
             var entryInDbAndCache = db.complexes().find(idInDbAndCache);
             assertThat(entryInDbAndCache).isNotNull();
             assertThat(db.complexes().find(idUnexistentMarkedEmptyInCache)).isNull();
@@ -979,7 +975,6 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             // this fetched from db and should exist
             assertThat(result.get(idInDbOnly)).isNotNull();
         });
-
     }
 
     @Test
@@ -999,13 +994,13 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var idUnexistentMarkedEmptyInCache = new Id(0, -2L, "aaa", Complex.Status.OK);
         var createdEntries = new HashMap<Id, Complex>();
 
-        db.tx(() -> {
+        tx.run(db -> {
             var entryOne = db.complexes().insert(new Complex(idInDbOnly));
             var entryTwo = db.complexes().insert(new Complex(idInDbAndUpdatedInCache));
             createdEntries.put(entryOne.getId(), entryOne);
             createdEntries.put(entryTwo.getId(), entryTwo);
         });
-        db.tx(() -> {
+        tx.run(db -> {
             var updatedEntry = new Complex(idInDbAndUpdatedInCache, "UPDATED");
             db.complexes().save(updatedEntry);
             assertThat(db.complexes().find(idUnexistentMarkedEmptyInCache)).isNull();
@@ -1036,12 +1031,12 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var idB = new Id(0, 0L, "bbb", Complex.Status.OK);
         var idC = new Id(0, 0L, "ccc", Complex.Status.OK);
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.complexes().insert(new Complex(idA, "A"));
             db.complexes().insert(new Complex(idB, "B"));
             db.complexes().insert(new Complex(idC, "C"));
         });
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.complexes().find(Set.of(idA, idB, idC)))
                     .extracting(Entity::getId)
                     .containsExactly(idA, idB, idC);
@@ -1060,11 +1055,11 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var firstId = new Id(0, 0L, "aaa", Complex.Status.OK);
         var secondId = new Id(0, 1L, "aaa", Complex.Status.OK);
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.complexes().insert(new Complex(firstId));
             db.complexes().insert(new Complex(secondId));
         });
-        db.tx(() -> {
+        tx.run(db -> {
             var result = db.complexes().find(Set.of(
                     firstId,
                     secondId
@@ -1132,7 +1127,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     }
 
     private void fillComplexTableForFindIn() {
-        db.tx(() -> IntStream.range(0, 4).mapToObj(this::getComplex).forEach(db.complexes()::save));
+        tx.run(db -> IntStream.range(0, 4).mapToObj(this::getComplex).forEach(db.complexes()::save));
     }
 
     @Test
@@ -1154,7 +1149,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     private void findInIdsFilteredAndOrdered(Set<Complex.Id> ids) {
         fillComplexTableForFindIn();
 
-        var actual = db.tx(() -> db.complexes().query()
+        var actual = tx.call(db -> db.complexes().query()
                 .ids(ids)
                 .filter(fb -> fb.where("id.d").eq(Complex.Status.OK))
                 .orderBy(ob -> ob.orderBy("value").descending())
@@ -1183,7 +1178,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void findInIdsViewFilteredAndOrdered(Set<Complex.Id> ids) {
         fillComplexTableForFindIn();
 
-        var actual = db.tx(() -> db.complexes().query()
+        var actual = tx.call(db -> db.complexes().query()
                 .ids(ids)
                 .filter(fb -> fb.where("id.d").eq(Complex.Status.OK))
                 .orderBy(ob -> ob.orderBy("value").descending())
@@ -1222,7 +1217,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     }
 
     private void fillIndexedTableForFindIn() {
-        db.tx(() -> IntStream.range(0, 8).mapToObj(this::getIndexedEntity).forEach(db.indexedTable()::save));
+        tx.run(db -> IntStream.range(0, 8).mapToObj(this::getIndexedEntity).forEach(db.indexedTable()::save));
     }
 
     @Test
@@ -1264,7 +1259,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     private void findInKeysFilteredAndOrdered(Set<IndexedEntity.Key> keys, boolean limited) {
         fillIndexedTableForFindIn();
 
-        var actual = db.tx(() -> {
+        List<IndexedEntity> actual = tx.call(db -> {
             var queryBuilder = db.indexedTable().query()
                     .index(IndexedEntity.VALUE_INDEX)
                     .keys(keys)
@@ -1312,7 +1307,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void findViewDistinct() {
         fillIndexedTableForFindIn();
 
-        var actualViews = db.tx(() -> db.indexedTable().query().find(IndexedEntity.ValueIdView.class, true));
+        var actualViews = tx.call(db -> db.indexedTable().query().find(IndexedEntity.ValueIdView.class, true));
 
         var actualValueIds = actualViews.stream()
                 .map(IndexedEntity.ValueIdView::getValueId)
@@ -1339,7 +1334,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     private void findInKeysViewFilteredAndOrdered(Set<IndexedEntity.Key> keys, boolean limited) {
         fillIndexedTableForFindIn();
 
-        var actual = db.tx(() -> {
+        List<IndexedEntity.View> actual = tx.call(db -> {
             var queryBuilder = db.indexedTable().query()
                     .index(IndexedEntity.VALUE_INDEX)
                     .keys(keys)
@@ -1363,7 +1358,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void indexMustExistToBeUsedInQueryBuilder() {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
-                db.tx(() -> db.indexedTable().query()
+                tx.run(db -> db.indexedTable().query()
                         .index("nonexistent_index", IndexOrder.DESCENDING)
                         .where("valueId2").neq(getIndexedEntityValue2(2))
                         .limit(5)
@@ -1376,31 +1371,31 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void uniqueIndex() {
         String verySameName = "valuableName";
         UniqueProject ue1 = new UniqueProject(new UniqueProject.Id("id1"), verySameName, 1);
-        db.tx(() -> db.table(UniqueProject.class).save(ue1));
-        db.tx(() -> db.table(UniqueProject.class).save(ue1).withVersion(2)); // no exception
+        tx.run(db -> db.table(UniqueProject.class).save(ue1));
+        tx.run(db -> db.table(UniqueProject.class).save(ue1.withVersion(2))); // no exception
         UniqueProject ue2 = new UniqueProject(new UniqueProject.Id("id2"), verySameName, 1);
         assertThatExceptionOfType(EntityAlreadyExistsException.class)
-                .isThrownBy(() -> db.tx(() -> db.table(UniqueProject.class).save(ue2)));
+                .isThrownBy(() -> tx.run(db -> db.table(UniqueProject.class).save(ue2)));
     }
 
     @Test
     public void sameEntityMultipleTables() {
         String verySameName = "valuableName";
         UniqueProject ue1 = new UniqueProject(new UniqueProject.Id("id1"), verySameName, 1);
-        db.tx(() -> {
+        tx.run(db -> {
             db.table(UniqueProject.class).save(ue1);
             db.table(TestEntities.SECOND_UNIQUE_PROJECT_TABLE).save(ue1.withVersion(2));
         });
-        UniqueProject firstTableProject = db.tx(() -> db.table(UniqueProject.class).find(ue1.getId()));
-        UniqueProject secondTableProject = db.tx(() -> db.table(TestEntities.SECOND_UNIQUE_PROJECT_TABLE).find(ue1.getId()));
+        UniqueProject firstTableProject = tx.call(db -> db.table(UniqueProject.class).find(ue1.getId()));
+        UniqueProject secondTableProject = tx.call(db -> db.table(TestEntities.SECOND_UNIQUE_PROJECT_TABLE).find(ue1.getId()));
 
         assertThat(firstTableProject.getVersion()).isEqualTo(1);
         assertThat(secondTableProject.getVersion()).isEqualTo(2);
 
-        db.tx(() -> db.table(UniqueProject.class).delete(ue1.getId()));
+        tx.run(db -> db.table(UniqueProject.class).delete(ue1.getId()));
 
-        firstTableProject = db.tx(() -> db.table(UniqueProject.class).find(ue1.getId()));
-        secondTableProject = db.tx(() -> db.table(TestEntities.SECOND_UNIQUE_PROJECT_TABLE).find(ue1.getId()));
+        firstTableProject = tx.call(db -> db.table(UniqueProject.class).find(ue1.getId()));
+        secondTableProject = tx.call(db -> db.table(TestEntities.SECOND_UNIQUE_PROJECT_TABLE).find(ue1.getId()));
 
         assertThat(firstTableProject).isNull();
         assertThat(secondTableProject.getVersion()).isEqualTo(2);
@@ -1408,24 +1403,24 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void doubleTxIsOk() {
-        db.tx(this::findRange);
+        tx.tx(this::findRange);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void findPartialId() {
-        db.tx(() -> db.bubbles().find(new Bubble.Id("b", null)));
+        tx.call(db -> db.bubbles().find(new Bubble.Id("b", null)));
     }
 
     @Test
     public void fixSnapshotVersionOnFirstQuery() {
         var projectId = new Project.Id("value");
 
-        db.tx(() -> db.tx(() -> db.projects().insert(new Project(projectId, "oldName"))));
+        tx.run(db1 -> tx.run(db2 -> db2.projects().insert(new Project(projectId, "oldName"))));
 
         String newName = "name";
-        Project project = db.tx(() -> {
-            db.separate().tx(() -> db.projects().save(new Project(projectId, newName)));
-            return db.projects().find(projectId);
+        Project project = tx.call(db1 -> {
+            tx.separate().run(db2 -> db2.projects().save(new Project(projectId, newName)));
+            return db1.projects().find(projectId);
         });
         assertThat(project.getName()).isEqualTo(newName);
     }
@@ -1434,34 +1429,34 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void dontCommitOnUserError() {
         var projectId = new Project.Id("value");
         try {
-            db.delayedWrites().tx(() -> {
+            tx.delayedWrites().call(db -> {
                 db.projects().save(new Project(projectId, "name"));
                 throw new RuntimeException("");
             });
         } catch (RuntimeException ignore) {
         }
-        assertThat(db.tx(() -> db.projects().find(projectId))).isNull();
+        assertThatObject(tx.call(db -> db.projects().find(projectId))).isNull();
 
         try {
-            db.immediateWrites().tx(() -> {
+            tx.immediateWrites().run(db -> {
                 db.projects().save(new Project(projectId, "name"));
                 throw new RuntimeException("");
             });
         } catch (RuntimeException ignore) {
         }
-        assertThat(db.tx(() -> db.projects().find(projectId))).isNull();
+        assertThatObject(tx.call(db -> db.projects().find(projectId))).isNull();
     }
 
     @Test
     public void immediateWrites() {
-        db.delayedWrites().noFirstLevelCache().tx(() -> {
+        tx.delayedWrites().noFirstLevelCache().run(db -> {
             var projectId = new Project.Id("value1");
             assertThat(db.projects().find(projectId)).isNull();
             db.projects().save(new Project(projectId, "name"));
             assertThat(db.projects().find(projectId)).isNull();
         });
 
-        db.immediateWrites().noFirstLevelCache().tx(() -> {
+        tx.immediateWrites().noFirstLevelCache().run(db -> {
             var projectId = new Project.Id("value2");
             var name = "name";
             assertThat(db.projects().find(projectId)).isNull();
@@ -1475,27 +1470,27 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var projectId = new Project.Id("value");
 
         String newName = "name";
-        db.tx(() -> db.tx(() -> db.projects().insert(new Project(projectId, newName))));
+        tx.run(db1 -> tx.call(db2 -> db2.projects().insert(new Project(projectId, newName))));
 
-        Project project = db.tx(() -> {
-            Project findedProject = db.projects().find(projectId);
-            db.separate().tx(() -> db.projects().save(new Project(projectId, "invisible")));
+        Project project = tx.call(db1 -> {
+            Project findedProject = db1.projects().find(projectId);
+            tx.separate().run(db2 -> db2.projects().save(new Project(projectId, "invisible")));
             return findedProject;
         });
         assertThat(project.getName()).isEqualTo(newName);
-        assertThat(db.tx(() -> db.projects().find(projectId)).getName()).isEqualTo("invisible");
+        assertThat(tx.call(db -> db.projects().find(projectId)).getName()).isEqualTo("invisible");
 
-        project = db.tx(() -> {
-            db.separate().tx(() -> db.projects().save(new Project(projectId, "invisible")));
-            db.projects().find(projectId);
-            return db.projects().save(new Project(projectId, newName));
+        project = tx.call(db1 -> {
+            tx.separate().run(db2 -> db2.projects().save(new Project(projectId, "invisible")));
+            db1.projects().find(projectId);
+            return db1.projects().save(new Project(projectId, newName));
         });
         assertThat(project.getName()).isEqualTo(newName);
     }
 
     @Test
     public void findByPredicate() {
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().insert(
                     new Project(new Project.Id("unnamed-p1"), null),
                     new Project(new Project.Id("named-p2"), "P2"),
@@ -1515,7 +1510,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             );
         });
 
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.projects().findNamed()).containsExactlyInAnyOrder(
                     new Project(new Project.Id("named-p3"), "P3"),
                     new Project(new Project.Id("named-p2"), "P2")
@@ -1550,12 +1545,12 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .mapToObj(i -> new Project(new Project.Id("named-p" + i), "P" + i))
                 .collect(toList());
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().insert(new Project(new Project.Id("unnamed-p1"), null));
             db.projects().insertAll(named);
         });
 
-        db.tx(() -> {
+        tx.run(db -> {
             final List<Project> topNamed = db.projects().findTopNamed(10);
             assertThat(topNamed).hasSize(10);
         });
@@ -1614,7 +1609,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void simpleCrudInTheSameTx() {
-        db.tx(() -> {
+        tx.run(db -> {
             Project p1 = new Project(new Project.Id("1"), "named");
             db.projects().save(p1); // save() is pending until end of tx
 
@@ -1627,7 +1622,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             Project p4 = db.projects().find(new Project.Id("1"));
             assertThat(p4).isEqualTo(new Project(new Project.Id("1"), "renamed"));
         });
-        db.tx(() -> {
+        tx.run(db -> {
             Project p1 = db.projects().find(new Project.Id("1"));
             assertThat(p1).isEqualTo(new Project(new Project.Id("1"), "renamed"));
             db.projects().delete(new Project.Id("1")); // delete() is pending
@@ -1635,7 +1630,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             Project p5 = db.projects().find(new Project.Id("1"));
             assertThat(p5).isNull(); // now it's deleted
         });
-        db.tx(() -> {
+        tx.run(db -> {
             Project p1 = db.projects().find(new Project.Id("1"));
             assertThat(p1).isNull(); // now it's deleted
         });
@@ -1659,7 +1654,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         assertThatExceptionOfType(OptimisticLockException.class)
                 .isThrownBy(tx3::commit);
 
-        Project p4 = db.tx(() -> db.table(Project.class).find(new Project.Id("1")));
+        Project p4 = tx.call(db -> db.table(Project.class).find(new Project.Id("1")));
         assertThat(p4).isEqualTo(new Project(new Project.Id("1"), p2.getName() + "y"));
     }
 
@@ -1703,7 +1698,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         tx2.table(Project.class).save(new Project(new Project.Id("1"), "y"));
         tx1.commit();
         tx2.commit();
-        assertThat(db.tx(() -> db.table(Project.class).find(new Project.Id("1"))))
+        assertThatObject(tx.call(db -> db.table(Project.class).find(new Project.Id("1"))))
                 .isEqualTo(new Project(new Project.Id("1"), "y"));
     }
 
@@ -1723,14 +1718,14 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void allTypes() {
-        TypeFreak t1 = db.tx(() -> db.typeFreaks().save(newTypeFreak(1, "aaa", "bbb")));
-        TypeFreak t2 = db.tx(() -> db.typeFreaks().find(new TypeFreak.Id("tf", 1)));
+        TypeFreak t1 = tx.call(db -> db.typeFreaks().save(newTypeFreak(1, "aaa", "bbb")));
+        TypeFreak t2 = tx.call(db -> db.typeFreaks().find(new TypeFreak.Id("tf", 1)));
         assertThat(t2).isEqualTo(t1);
     }
 
     @Test
     public void allTypesNull() {
-        TypeFreak t1 = db.tx(() -> {
+        TypeFreak t1 = tx.call(db -> {
             TypeFreak t = new TypeFreak(new TypeFreak.Id("x", 1),
                     true,
                     (byte) 111,
@@ -1774,13 +1769,13 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             db.typeFreaks().save(t);
             return t;
         });
-        TypeFreak t2 = db.tx(() -> db.typeFreaks().find(new TypeFreak.Id("x", 1)));
+        TypeFreak t2 = tx.call(db -> db.typeFreaks().find(new TypeFreak.Id("x", 1)));
         assertThat(t2).isEqualTo(t1);
     }
 
     @Test
     public void allTypesWithNulls() {
-        TypeFreak t1 = db.tx(() -> {
+        TypeFreak t1 = tx.call(db -> {
             TypeFreak t = new TypeFreak(new TypeFreak.Id("x", 1),
                     true,
                     (byte) 111,
@@ -1824,7 +1819,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             db.typeFreaks().save(t);
             return t;
         });
-        TypeFreak t2 = db.tx(() -> db.typeFreaks().find(new TypeFreak.Id("x", 1)));
+        TypeFreak t2 = tx.call(db -> db.typeFreaks().find(new TypeFreak.Id("x", 1)));
         assertThat(t2).isEqualTo(t1);
     }
 
@@ -1840,14 +1835,14 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 List.of(p1.getId(), p2.getId()),
                 List.of(c1.getId(), c2.getId())
         );
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().save(p1);
             db.projects().save(p2);
             db.complexes().save(c1);
             db.complexes().save(c2);
             db.referrings().save(r);
         });
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.referrings().find(r.getId())).isEqualTo(r);
             assertThat(db.projects().find(r.getProject())).isEqualTo(p1);
             assertThat(db.complexes().find(r.getComplex())).isEqualTo(c1);
@@ -1860,7 +1855,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void severalWriteOperationsInTX() {
         Complex.Id complexId = new Complex.Id(1, 1L, "c", Complex.Status.OK);
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().save(new Project(new Project.Id("1"), "p11"));
             db.projects().save(new Project(new Project.Id("2"), "p2"));
             db.projects().save(new Project(new Project.Id("1"), "p12"));
@@ -1871,7 +1866,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             db.projects().delete(new Project.Id("2"));
         });
 
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.projects().find(new Project.Id("1"))).isNull();
             assertThat(db.projects().find(new Project.Id("2"))).isNull();
             assertThat(db.complexes().find(complexId)).isNull();
@@ -1880,7 +1875,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void insert() {
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().insert(new Project(new Project.Id("unnamed-p1"), null));
             db.projects().insert(new Project(new Project.Id("named-p2"), "P2"));
             db.projects().insert(new Project(new Project.Id("named-p3"), "P3"));
@@ -1889,24 +1884,20 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Project p1 = new Project(new Project.Id("1"), "p1");
         Complex complex = new Complex(complexId);
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().insert(p1);
             db.complexes().insert(complex);
         });
 
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.projects().find(new Project.Id("1"))).isEqualTo(p1);
             assertThat(db.complexes().find(complexId)).isEqualTo(complex);
         });
         assertThatExceptionOfType(EntityAlreadyExistsException.class)
-                .isThrownBy(() -> db.tx(() -> {
-                    db.projects().insert(p1);
-                }));
+                .isThrownBy(() -> tx.run(db -> db.projects().insert(p1)));
 
         assertThatExceptionOfType(EntityAlreadyExistsException.class)
-                .isThrownBy(() -> db.tx(() -> {
-                    db.complexes().insert(complex);
-                }));
+                .isThrownBy(() -> tx.run(db -> db.complexes().insert(complex)));
 
     }
 
@@ -1917,18 +1908,18 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
         //this is a problem for one tx.
         assertThatExceptionOfType(EntityAlreadyExistsException.class)
-                .isThrownBy(() -> db.tx(() -> {
+                .isThrownBy(() -> tx.run(db -> {
                     db.projects().insert(p1);
                     //this is a problem for one tx.
                     db.projects().insert(p12);
                 }));
 
-        db.tx(() -> db.projects().insert(p1));
+        tx.run(db -> db.projects().insert(p1));
 
         AtomicBoolean executed = new AtomicBoolean(false);
         //already exists only on commit
         assertThatExceptionOfType(EntityAlreadyExistsException.class)
-                .isThrownBy(() -> db.tx(() -> {
+                .isThrownBy(() -> tx.run(db -> {
                     db.projects().insert(p1);
                     //already exists only on commit
                     executed.set(true);
@@ -1938,26 +1929,24 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void updateSimpleFieldById() {
-        db.tx(() -> db.projects().insert(new Project(new Project.Id("1"), "p1")));
+        tx.run(db -> db.projects().insert(new Project(new Project.Id("1"), "p1")));
 
-        db.tx(() -> db.projects().updateName(new Project.Id("1"), "NEW-P1-NAME"));
+        tx.run(db -> db.projects().updateName(new Project.Id("1"), "NEW-P1-NAME"));
 
-        db.tx(() -> {
-            assertThat(db.projects().find(new Project.Id("1")))
-                    .isNotNull()
-                    .extracting(Project::getName).isEqualTo("NEW-P1-NAME");
-        });
+        tx.run(db -> assertThat(db.projects().find(new Project.Id("1")))
+                .isNotNull()
+                .extracting(Project::getName).isEqualTo("NEW-P1-NAME"));
     }
 
     @Test
     public void updateComplexFieldByComplexId() {
         TypeFreak tf = newTypeFreak(100500, "AAA", "BBB");
-        db.tx(() -> db.typeFreaks().insert(tf));
+        tx.run(db -> db.typeFreaks().insert(tf));
 
         Embedded newEmbedded = new Embedded(new A("ZZZ"), new B("YYY"));
-        db.tx(() -> db.typeFreaks().updateEmbedded(tf.getId(), newEmbedded));
+        tx.run(db -> db.typeFreaks().updateEmbedded(tf.getId(), newEmbedded));
 
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.typeFreaks().find(tf.getId()))
                     .isNotNull()
                     .extracting(TypeFreak::getEmbedded).isEqualTo(newEmbedded);
@@ -1966,14 +1955,12 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void findByComplexIdUsingPredicates() {
-        db.tx(() -> db.typeFreaks().insert(
+        tx.run(db -> db.typeFreaks().insert(
                 newTypeFreak(0, "AAA1", "bbb"),
                 newTypeFreak(1, "AAA2", "bbb")));
 
-        db.tx(() -> {
-            assertThat(db.typeFreaks().findByPredicateWithComplexId(new TypeFreak.Id("tf", 0)))
-                    .isEqualTo(newTypeFreak(0, "AAA1", "bbb"));
-        });
+        tx.run(db -> assertThat(db.typeFreaks().findByPredicateWithComplexId(new TypeFreak.Id("tf", 0)))
+                .isEqualTo(newTypeFreak(0, "AAA1", "bbb")));
     }
 
     @Test
@@ -1981,9 +1968,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Project projA = new Project(new Project.Id("A"), "aaa");
         Project projB = new Project(new Project.Id("B"), "bbb");
         Project proj0 = new Project(new Project.Id("0"), "000");
-        db.tx(() -> db.projects().insert(projA, projB, proj0));
+        tx.run(db -> db.projects().insert(projA, projB, proj0));
 
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.projects().findByPredicateWithManyIds(Set.of(new Project.Id("A"), new Project.Id("B"))))
                     .containsOnly(projA, projB);
             assertThat(db.projects().findByPredicateWithManyIdValues(Set.of("A", "B")))
@@ -1994,11 +1981,11 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void findViewById() {
         TypeFreak tf1 = newTypeFreak(0, "AAA1", "bbb");
-        db.tx(() -> db.typeFreaks().insert(
+        tx.run(db -> db.typeFreaks().insert(
                 tf1,
                 newTypeFreak(1, "AAA2", "bbb")));
 
-        db.tx(() -> {
+        tx.run(db -> {
             TypeFreak.View found = db.typeFreaks().find(TypeFreak.View.class, tf1.getId());
             assertThat(found).isEqualTo(new TypeFreak.View(tf1.getId(), tf1.getEmbedded()));
         });
@@ -2007,11 +1994,11 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void findViewTypeConversion() {
         TypeFreak tf1 = newTypeFreak(0, "AAA1", "bbb");
-        db.tx(() -> db.typeFreaks().insert(
+        tx.run(db -> db.typeFreaks().insert(
                 tf1,
                 newTypeFreak(1, "AAA2", "bbb")));
 
-        db.tx(() -> {
+        tx.run(db -> {
             TypeFreak.StringView found = db.typeFreaks().find(TypeFreak.StringView.class, tf1.getId());
             assertThat(found.getId()).isEqualTo(tf1.getId());
             // ...sure looks like JSON to me:
@@ -2037,9 +2024,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 expectedViews.get(expectedViews.size() - 1).getId()
         );
 
-        db.tx(() -> db.typeFreaks().insertAll(toInsert));
+        tx.run(db -> db.typeFreaks().insertAll(toInsert));
 
-        db.tx(() -> {
+        tx.run(db -> {
             List<TypeFreak.View> found = db.typeFreaks().find(TypeFreak.View.class, findRange);
             assertThat(found).containsExactlyInAnyOrderElementsOf(expectedViews);
         });
@@ -2055,9 +2042,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             expectedViews.add(new TypeFreak.View(tf.getId(), tf.getEmbedded()));
         }
 
-        db.tx(() -> db.typeFreaks().insertAll(toInsert));
+        tx.run(db -> db.typeFreaks().insertAll(toInsert));
 
-        db.tx(() -> {
+        tx.run(db -> {
             List<TypeFreak.View> found = db.typeFreaks().findAll(TypeFreak.View.class);
             assertThat(found).containsExactlyInAnyOrderElementsOf(expectedViews);
         });
@@ -2077,29 +2064,26 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             embeddedAsToFind.add(embeddedA);
         }
 
-        db.tx(() -> db.typeFreaks().insertAll(toInsert));
+        tx.run(db -> db.typeFreaks().insertAll(toInsert));
 
-        db.tx(() -> {
-            List<TypeFreak.View> found = db.typeFreaks().findViewWithEmbeddedAIn(embeddedAsToFind);
-            assertThat(found).containsExactlyInAnyOrderElementsOf(toFind);
-        });
+        List<TypeFreak.View> found = tx.call(db -> db.typeFreaks().findViewWithEmbeddedAIn(embeddedAsToFind));
+        assertThat(found).containsExactlyInAnyOrderElementsOf(toFind);
     }
 
     @Test
     public void findRangeWithPrimitiveId() {
-        db.tx(() -> db.primitives().insert(
+        tx.run(db -> db.primitives().insert(
                 new Primitive(new Primitive.Id(1), 100500),
                 new Primitive(new Primitive.Id(42), 9000),
                 new Primitive(new Primitive.Id(-100500), 0)
         ));
 
-        db.tx(() -> {
-            assertThat(db.primitives().find(Range.create(new Primitive.Id(-5), new Primitive.Id(50))))
-                    .containsOnly(
-                            new Primitive(new Primitive.Id(1), 100500),
-                            new Primitive(new Primitive.Id(42), 9000)
-                    );
-        });
+        List<Primitive> found = tx.call(db -> db.primitives()
+                .find(Range.create(new Primitive.Id(-5), new Primitive.Id(50))));
+        assertThat(found).containsOnly(
+                new Primitive(new Primitive.Id(1), 100500),
+                new Primitive(new Primitive.Id(42), 9000)
+        );
     }
 
     @Test
@@ -2109,9 +2093,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Complex c3 = new Complex(new Complex.Id(999_999, 15L, "UUU", Complex.Status.OK));
         Complex c4 = new Complex(new Complex.Id(999_999, 0L, "UUU", Complex.Status.OK));
         Complex c5 = new Complex(new Complex.Id(999_000, 0L, "UUU", Complex.Status.OK));
-        db.tx(() -> db.complexes().insert(c1, c2, c3, c4, c5));
+        tx.run(db -> db.complexes().insert(c1, c2, c3, c4, c5));
 
-        List<Complex> found = db.tx(() -> db.complexes().findAll());
+        List<Complex> found = tx.call(db -> db.complexes().findAll());
         assertThat(found).containsExactly(c5, c4, c3, c2, c1);
     }
 
@@ -2123,9 +2107,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Complex c4 = new Complex(new Complex.Id(999_999, 0L, "UUU", Complex.Status.OK));
         Complex c5 = new Complex(new Complex.Id(999_000, 0L, "UUU", Complex.Status.OK));
         Complex c6 = new Complex(new Complex.Id(999_000, 0L, "AAA", Complex.Status.OK));
-        db.tx(() -> db.complexes().insert(c1, c2, c3, c4, c5, c6));
+        tx.run(db -> db.complexes().insert(c1, c2, c3, c4, c5, c6));
 
-        List<Complex> found = db.tx(() -> db.complexes().find(
+        List<Complex> found = tx.call(db -> db.complexes().find(
                 Range.create(
                         new Complex.Id(999_000, 0L, "AAA", null),
                         new Complex.Id(999_000, 0L, "UUU", null)
@@ -2135,13 +2119,13 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void findByPredicateResultsAreOrderedByIdAscending() {
-        db.tx(() -> db.projects().insert(
+        tx.run(db -> db.projects().insert(
                 new Project(new Project.Id("named-p3"), "P3"),
                 new Project(new Project.Id("unnamed-p1"), null),
                 new Project(new Project.Id("named-p2"), "P2")
         ));
 
-        assertThat(db.tx(() -> db.projects().findNamed())).containsExactly(
+        assertThatList(tx.call(db -> db.projects().findNamed())).containsExactly(
                 new Project(new Project.Id("named-p2"), "P2"),
                 new Project(new Project.Id("named-p3"), "P3")
         );
@@ -2149,53 +2133,51 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void projections() {
-        db.tx(() -> {
+        tx.run(db -> {
             db.table(Book.class).save(new Book(new Book.Id("1"), 1, "title1", List.of("author1")));
             db.table(Book.class).save(new Book(new Book.Id("2"), 1, "title2", List.of("author2")));
             db.table(Book.class).save(new Book(new Book.Id("3"), 1, null, List.of("author1", "author2")));
             db.table(Book.class).save(new Book(new Book.Id("4"), 1, "title1", List.of()));
         });
 
-        assertThat(db.tx(() -> db.table(Book.ByTitle.class).countAll()))
+        assertThat((long) tx.call(db -> db.table(Book.ByTitle.class).countAll()))
                 .isEqualTo(3L);
-        assertThat(db.tx(() -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title1", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title1", null)))))
                 .hasSize(2);
-        assertThat(db.tx(() -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title2", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title2", null)))))
                 .hasSize(1);
 
-        assertThat(db.tx(() -> db.table(Book.ByAuthor.class).countAll()))
+        assertThat((long) tx.call(db -> db.table(Book.ByAuthor.class).countAll()))
                 .isEqualTo(4L);
-        assertThat(db.tx(() -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author1", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author1", null)))))
                 .hasSize(2);
-        assertThat(db.tx(() -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author2", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author2", null)))))
                 .hasSize(2);
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.table(Book.class).modifyIfPresent(new Book.Id("1"), b -> b.updateTitle("title2"));
             db.table(Book.class).modifyIfPresent(new Book.Id("2"), b -> b.updateTitle(null));
             db.table(Book.class).modifyIfPresent(new Book.Id("3"), b -> b.withAuthors(List.of("author2")));
             db.table(Book.class).modifyIfPresent(new Book.Id("4"), b -> b.withAuthors(List.of("author1", "author2")));
         });
 
-        assertThat(db.tx(() -> db.table(Book.ByTitle.class).countAll()))
+        assertThat((long) tx.call(db -> db.table(Book.ByTitle.class).countAll()))
                 .isEqualTo(2L);
-        assertThat(db.tx(() -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title1", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title1", null)))))
                 .hasSize(1);
-        assertThat(db.tx(() -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title2", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByTitle.class).find(Range.create(new Book.ByTitle.Id("title2", null)))))
                 .hasSize(1);
 
-        assertThat(db.tx(() -> db.table(Book.ByAuthor.class).countAll()))
+        assertThat((long) tx.call(db -> db.table(Book.ByAuthor.class).countAll()))
                 .isEqualTo(5L);
-        assertThat(db.tx(() -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author1", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author1", null)))))
                 .hasSize(2);
-        assertThat(db.tx(() -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author2", null)))))
+        assertThatList(tx.call(db -> db.table(Book.ByAuthor.class).find(Range.create(new Book.ByAuthor.Id("author2", null)))))
                 .hasSize(3);
 
-        db.tx(() -> db.table(Book.class).findAll().forEach(b -> db.table(Book.class).delete(b.getId())));
-        assertThat(db.tx(() -> db.table(Book.ByTitle.class).countAll()))
-                .isEqualTo(0L);
-        assertThat(db.tx(() -> db.table(Book.ByAuthor.class).countAll()))
-                .isEqualTo(0L);
+        tx.run(db -> db.table(Book.class).findAll().forEach(b -> db.table(Book.class).delete(b.getId())));
+        assertThat((long) tx.call(db -> db.table(Book.ByTitle.class).countAll())).isEqualTo(0L);
+        assertThat((long) tx.call(db -> db.table(Book.ByAuthor.class).countAll())).isEqualTo(0L);
     }
 
     /**
@@ -2223,22 +2205,22 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     }
 
     private void parallelTx(boolean shouldThrown, boolean writeTx, Consumer<Table<Complex>> consumer) {
-        RepositoryTransaction tx = startTransaction();
+        RepositoryTransaction repositoryTransaction = startTransaction();
         if (writeTx) {
-            tx.table(Book.class).save(new Book(new Book.Id("1"), 1, "title1", List.of("author1")));
+            repositoryTransaction.table(Book.class).save(new Book(new Book.Id("1"), 1, "title1", List.of("author1")));
         }
-        consumer.accept(tx.table(Complex.class));
+        consumer.accept(repositoryTransaction.table(Complex.class));
 
-        db.tx(() -> db.complexes().insert(new Complex(new Complex.Id(1, 2L, "c", Complex.Status.OK))));
+        tx.run(db -> db.complexes().insert(new Complex(new Complex.Id(1, 2L, "c", Complex.Status.OK))));
 
         Runnable runnable = () -> {
             try {
-                consumer.accept(tx.table(Complex.class));
+                consumer.accept(repositoryTransaction.table(Complex.class));
             } catch (Exception e) {
-                tx.rollback();
+                repositoryTransaction.rollback();
                 throw e;
             }
-            tx.commit();
+            repositoryTransaction.commit();
         };
         if (shouldThrown) {
             assertThatExceptionOfType(OptimisticLockException.class).isThrownBy(runnable::run);
@@ -2246,7 +2228,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             runnable.run();
         }
 
-        db.tx(() -> db.complexes().deleteAll());
+        tx.run(db -> db.complexes().deleteAll());
     }
 
     @Test
@@ -2254,7 +2236,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         class BusinessException extends RuntimeException {
         }
 
-        assertThatExceptionOfType(BusinessException.class).isThrownBy(() -> db.tx(() -> {
+        assertThatExceptionOfType(BusinessException.class).isThrownBy(() -> tx.run(db -> {
             db.primitives().find(new Primitive.Id(25));
             throw new BusinessException();
         }));
@@ -2263,37 +2245,39 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void readOnlyTransaction() {
         assertThatExceptionOfType(IllegalTransactionIsolationLevelException.class)
-                .isThrownBy(() -> db.readOnly().run(() -> db.projects().save(new Project(new Project.Id("13"), "p13"))))
+                // FIXME
+                .isThrownBy(() -> tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().save(new Project(new Project.Id("13"), "p13"))))
                 .withMessage("Mutable operations are not allowed for isolation level ONLINE_CONSISTENT_READ_ONLY");
     }
 
     @Test
     public void ctorValidationFailure() {
         EntityWithValidation goodValue = new EntityWithValidation(new EntityWithValidation.Id("hey"), 43L);
-        db.tx(() -> {
+        tx.run(db -> {
             db.entitiesWithValidation().save(goodValue);
             db.entitiesWithValidation().save(EntityWithValidation.BAD_VALUE);
         });
 
-        assertThat(db.tx(() -> db.entitiesWithValidation().find(goodValue.getId())))
-                .isEqualTo(goodValue);
-        assertThatExceptionOfType(ConversionException.class)
-                .isThrownBy(() -> db.tx(() -> db.entitiesWithValidation().find(EntityWithValidation.BAD_VALUE.getId())));
+        assertThatObject(tx.call(db -> db.entitiesWithValidation().find(goodValue.getId()))).isEqualTo(goodValue);
+        assertThatExceptionOfType(ConversionException.class).isThrownBy(() -> tx.run(db ->
+                db.entitiesWithValidation().find(EntityWithValidation.BAD_VALUE.getId())));
     }
 
     @Test
     public void viewCtorValidationFailure() {
         EntityWithValidation goodValue = new EntityWithValidation(new EntityWithValidation.Id("hey"), 43L);
-        db.tx(() -> {
+        tx.run(db -> {
             db.entitiesWithValidation().save(goodValue);
             db.entitiesWithValidation().save(EntityWithValidation.BAD_VALUE_IN_VIEW);
         });
 
-        assertThat(db.tx(() -> db.entitiesWithValidation().find(EntityWithValidation.OnlyVal.class, goodValue.getId())))
-                .isEqualTo(new EntityWithValidation.OnlyVal(goodValue.getValue()));
-        assertThatExceptionOfType(ConversionException.class)
-                .isThrownBy(() -> db.tx(() -> db.entitiesWithValidation()
-                        .find(EntityWithValidation.OnlyVal.class, EntityWithValidation.BAD_VALUE_IN_VIEW.getId())));
+        assertThatObject(tx.call(db ->
+                db.entitiesWithValidation().find(EntityWithValidation.OnlyVal.class, goodValue.getId())
+        )).isEqualTo(new EntityWithValidation.OnlyVal(goodValue.getValue()));
+        assertThatExceptionOfType(ConversionException.class).isThrownBy(() -> tx.run(db ->
+                db.entitiesWithValidation()
+                        .find(EntityWithValidation.OnlyVal.class, EntityWithValidation.BAD_VALUE_IN_VIEW.getId())
+        ));
     }
 
     @Test
@@ -2302,10 +2286,10 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Complex c2 = new Complex(new Complex.Id(999_999, 42L, "ZZZ", Complex.Status.OK));
         Complex c3 = new Complex(new Complex.Id(999_999, 76L, "ZZZ", Complex.Status.OK));
 
-        db.tx(() -> db.complexes().insert(c1, c2, c3));
+        tx.run(db -> db.complexes().insert(c1, c2, c3));
 
-        assertThat(
-                db.tx(() -> db.complexes().query()
+        assertThatList(
+                tx.call(db -> db.complexes().query()
                         .where("id").eq(c1.getId())
                         .orderBy(ob -> ob.orderBy("id").ascending())
                         .find())
@@ -2318,10 +2302,10 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Complex c2 = new Complex(new Complex.Id(999_999, 42L, "ZZZ", Complex.Status.OK));
         Complex c3 = new Complex(new Complex.Id(999_999, 76L, "ZZZ", Complex.Status.OK));
 
-        db.tx(() -> db.complexes().insert(c1, c2, c3));
+        tx.run(db -> db.complexes().insert(c1, c2, c3));
 
-        assertThat(
-                db.tx(() -> db.complexes().query()
+        assertThatList(
+                tx.call(db -> db.complexes().query()
                         .where("id").neq(c1.getId())
                         .orderBy(ob -> ob.orderBy("id").ascending())
                         .find())
@@ -2334,10 +2318,10 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Complex c2 = new Complex(new Complex.Id(999_999, 42L, "ZZZ", Complex.Status.OK));
         Complex c3 = new Complex(new Complex.Id(999_999, 76L, "ZZZ", Complex.Status.OK));
 
-        db.tx(() -> db.complexes().insert(c1, c2, c3));
+        tx.run(db -> db.complexes().insert(c1, c2, c3));
 
-        assertThat(
-                db.tx(() -> db.complexes().query()
+        assertThatList(
+                tx.call(db -> db.complexes().query()
                         .where("id").gt(c1.getId())
                         .orderBy(ob -> ob.orderBy("id").ascending())
                         .find())
@@ -2349,10 +2333,10 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Complex c1 = new Complex(new Complex.Id(999_999, 15L, "ZZZ", Complex.Status.OK));
         Complex c2 = new Complex(new Complex.Id(999_999, 42L, "ZZZ", Complex.Status.OK));
         Complex c3 = new Complex(new Complex.Id(999_999, 76L, "ZZZ", Complex.Status.OK));
-        db.tx(() -> db.complexes().insert(c1, c2, c3));
+        tx.run(db -> db.complexes().insert(c1, c2, c3));
 
-        assertThat(
-                db.tx(() -> db.complexes().query()
+        assertThatList(
+                tx.call(db -> db.complexes().query()
                         .where("id").lt(c3.getId())
                         .orderBy(ob -> ob.orderBy("id").descending())
                         .find())
@@ -2365,9 +2349,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         BytePkEntity e1 = BytePkEntity.valueOf(1, 2, 3);
         BytePkEntity e2 = BytePkEntity.valueOf(1, 2, 4);
         BytePkEntity e3 = BytePkEntity.valueOf(1, 3, 255);
-        db.tx(() -> db.bytePkEntities().insert(e0, e1, e2, e3));
+        tx.run(db -> db.bytePkEntities().insert(e0, e1, e2, e3));
 
-        assertThat(db.tx(() -> db.bytePkEntities().query()
+        assertThatList(tx.call(db -> db.bytePkEntities().query()
                 .where("id").lt(e3.getId())
                 .orderBy(ob -> ob.orderBy("id").descending())
                 .find()
@@ -2380,9 +2364,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         BytePkEntity e1 = BytePkEntity.valueOf(1, 2, 3);
         BytePkEntity e2 = BytePkEntity.valueOf(1, 2, 4);
         BytePkEntity e3 = BytePkEntity.valueOf(1, 3, 255);
-        db.tx(() -> db.bytePkEntities().insert(e0, e1, e2, e3));
+        tx.run(db -> db.bytePkEntities().insert(e0, e1, e2, e3));
 
-        assertThat(db.tx(() -> db.bytePkEntities().query()
+        assertThatList(tx.call(db -> db.bytePkEntities().query()
                 .where("id").gt(e1.getId())
                 .orderBy(ob -> ob.orderBy("id").ascending())
                 .find()
@@ -2392,9 +2376,9 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void byteIdEmpty() {
         BytePkEntity e0 = BytePkEntity.valueOf();
-        db.tx(() -> db.bytePkEntities().insert(e0));
+        tx.run(db -> db.bytePkEntities().insert(e0));
 
-        assertThat(db.tx(() -> db.bytePkEntities().find(e0.getId()))).isEqualTo(e0);
+        assertThatObject(tx.call(db -> db.bytePkEntities().find(e0.getId()))).isEqualTo(e0);
     }
 
     @Test
@@ -2402,19 +2386,19 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Supabubble sa = new Supabubble(new Supabubble.Id(new Project.Id("naher"), "bubble-A"));
         Supabubble sb = new Supabubble(new Supabubble.Id(new Project.Id("naher"), "bubble-B"));
         Supabubble sc = new Supabubble(new Supabubble.Id(new Project.Id("naher"), "bubble-C"));
-        db.tx(() -> db.supabubbles().insert(sa, sb, sc));
+        tx.run(db -> db.supabubbles().insert(sa, sb, sc));
 
-        assertThat(
-                db.tx(() -> db.supabubbles().query()
+        assertThatList(tx.call(db ->
+                db.supabubbles().query()
                         .where("id").lt(sc.getId())
                         .orderBy(ob -> ob.orderBy("id").descending())
-                        .find())
-        ).containsExactly(sb, sa);
+                        .find()
+        )).containsExactly(sb, sa);
     }
 
     @Test
     public void checkCanMergeWorkProperly() {
-        db.tx(() -> {
+        tx.run(db -> {
             Project p1 = new Project(new Project.Id("1"), "first");
             Project p2 = new Project(new Project.Id("2"), "second");
 
@@ -2424,19 +2408,18 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         });
     }
 
-
     @Test
     public void doMultipleSaveInOneTx() {
         Project p1 = new Project(new Project.Id("1"), "first");
         Project p2 = new Project(new Project.Id("2"), "second");
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().save(p1);
             db.projects().save(p2);
         });
 
-        assertThat(db.tx(() -> db.projects().find(p1.getId()))).isEqualTo(p1);
-        assertThat(db.tx(() -> db.projects().find(p2.getId()))).isEqualTo(p2);
+        assertThatObject(tx.call(db -> db.projects().find(p1.getId()))).isEqualTo(p1);
+        assertThatObject(tx.call(db -> db.projects().find(p2.getId()))).isEqualTo(p2);
     }
 
     @Test
@@ -2444,15 +2427,15 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         // merged to upsert, integration test, that's merge correct
         Project p1 = new Project(new Project.Id("1"), "project1");
         Project p2 = new Project(new Project.Id("2"), "project2");
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().delete(p1.getId());
             db.projects().insert(p1);
             db.projects().delete(p2.getId());
             db.projects().insert(p2);
         });
 
-        assertThat(db.tx(() -> db.projects().find(p1.getId()))).isEqualTo(p1);
-        assertThat(db.tx(() -> db.projects().find(p2.getId()))).isEqualTo(p2);
+        assertThatObject(tx.call(db -> db.projects().find(p1.getId()))).isEqualTo(p1);
+        assertThatObject(tx.call(db -> db.projects().find(p2.getId()))).isEqualTo(p2);
     }
 
     @Test
@@ -2460,13 +2443,15 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         Project p1 = new Project(new Project.Id("1"), "first");
         Project p2 = new Project(new Project.Id("2"), "second");
 
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().save(p1);
             db.projects().save(p2);
         });
-        RepositoryTransaction tx = repository.startTransaction(TxOptions.create(IsolationLevel.STALE_CONSISTENT_READ_ONLY));
-        assertThat(tx.table(Project.class).find(p1.getId())).isNotNull();
-        assertThat(tx.table(Project.class).find(p2.getId())).isNotNull();
+        RepositoryTransaction repositoryTransaction = repository.startTransaction(
+                TxOptions.create(IsolationLevel.STALE_CONSISTENT_READ_ONLY)
+        );
+        assertThat(repositoryTransaction.table(Project.class).find(p1.getId())).isNotNull();
+        assertThat(repositoryTransaction.table(Project.class).find(p2.getId())).isNotNull();
     }
 
     @Test
@@ -2501,10 +2486,10 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void findEntityAndViewWithTheSameKey() {
         TypeFreak tf1 = newTypeFreak(0, "AAA1", "bbb");
-        db.tx(() -> db.typeFreaks().insert(tf1));
+        tx.run(db -> db.typeFreaks().insert(tf1));
 
         // find view by id and than find entity by id
-        db.tx(() -> {
+        tx.run(db -> {
             TypeFreak.View foundView = db.typeFreaks().find(TypeFreak.View.class, tf1.getId());
             assertThat(foundView).isEqualTo(new TypeFreak.View(tf1.getId(), tf1.getEmbedded()));
 
@@ -2513,7 +2498,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         });
 
         // find entity by id and than find view by id
-        db.tx(() -> {
+        tx.run(db -> {
             TypeFreak foundTF = db.typeFreaks().find(tf1.getId());
             assertThat(foundTF).isEqualTo(tf1);
 
@@ -2524,21 +2509,24 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void scanUpdateFails() {
-        Assertions.assertThatExceptionOfType(IllegalTransactionScanException.class)
-                .isThrownBy(() -> db.scan().run(() -> {
-                    db.projects().save(new Project(new Project.Id("1"), "p1"));
-                }));
+        assertThatExceptionOfType(IllegalTransactionScanException.class).isThrownBy(() -> tx.scan().run(() ->
+                // FIXME
+                BaseDb.current(TestDb.class).projects().save(new Project(new Project.Id("1"), "p1")))
+        );
     }
 
     @Test
     public void scanNotTruncated() {
         int maxPageSizeBiggerThatReal = 11_000;
 
-        db.tx(() -> IntStream.range(0, maxPageSizeBiggerThatReal).forEach(
+        tx.run(db -> IntStream.range(0, maxPageSizeBiggerThatReal).forEach(
                 i -> db.projects().save(new Project(new Project.Id("id_" + i), "name"))
         ));
 
-        List<Project> result = db.scan().withMaxSize(maxPageSizeBiggerThatReal).run(() -> db.projects().findAll());
+        List<Project> result = tx.scan().withMaxSize(maxPageSizeBiggerThatReal).run(() ->
+                // FIXME
+                BaseDb.current(TestDb.class).projects().findAll()
+        );
         assertThat(result).hasSize(maxPageSizeBiggerThatReal);
     }
 
@@ -2546,11 +2534,10 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void scanFind() {
         Project p1 = new Project(new Project.Id("1"), "p1");
 
-        db.tx(() -> {
-            db.projects().save(p1);
-        });
+        tx.run(db -> db.projects().save(p1));
 
-        Project result = db.scan().run(() -> db.projects().find(p1.getId()));
+        // FIXME
+        Project result = tx.scan().run(() -> BaseDb.current(TestDb.class).projects().find(p1.getId()));
         assertThat(result).isEqualTo(p1);
     }
 
@@ -2558,11 +2545,12 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     public void scanStreamAll() {
         int size = 10;
 
-        db.tx(() -> IntStream.range(0, size).forEach(
+        tx.run(db -> IntStream.range(0, size).forEach(
                 i -> db.projects().save(new Project(new Project.Id("id_" + i), "name"))
         ));
 
-        List<Project> result = db.scan().run(() -> db.projects().streamAll(1).collect(toList()));
+        // FIXME
+        List<Project> result = tx.scan().run(() -> BaseDb.current(TestDb.class).projects().streamAll(1).collect(toList()));
         assertThat(result).hasSize(size);
     }
 
@@ -2571,7 +2559,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         class BusinessException extends RuntimeException {
         }
 
-        assertThatExceptionOfType(BusinessException.class).isThrownBy(() -> db.tx(() -> {
+        assertThatExceptionOfType(BusinessException.class).isThrownBy(() -> tx.run(db -> {
             db.primitives().find(new Primitive.Id(25));
             throw new BusinessException();
         }));
@@ -2583,10 +2571,11 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 new NonDeserializableEntity.Id("ru-vladimirsky-central-001"),
                 new NonDeserializableObject()
         );
-        db.tx(() -> db.table(NonDeserializableEntity.class).insert(nonDeserializableEntity));
+        tx.run(db -> db.table(NonDeserializableEntity.class).insert(nonDeserializableEntity));
 
-        assertThatExceptionOfType(ConversionException.class)
-                .isThrownBy(() -> db.tx(() -> db.table(NonDeserializableEntity.class).find(nonDeserializableEntity.getId())));
+        assertThatExceptionOfType(ConversionException.class).isThrownBy(() ->
+                tx.run(db -> db.table(NonDeserializableEntity.class).find(nonDeserializableEntity.getId()))
+        );
     }
 
     @Test
@@ -2595,17 +2584,20 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 new NonDeserializableEntity.Id("ru-vladimirsky-central-001"),
                 new NonDeserializableObject()
         );
-        db.tx(() -> db.table(NonDeserializableEntity.class).insert(nonDeserializableEntity));
+        tx.run(db -> db.table(NonDeserializableEntity.class).insert(nonDeserializableEntity));
 
         assertThatExceptionOfType(ConversionException.class).isThrownBy(() ->
-                db.readOnly().run(() -> db.table(NonDeserializableEntity.class).readTable(defaultReadTableParamsNonLegacy()).collect(toList()))
+                // FIXME
+                tx.readOnly().run(() -> BaseDb.current(TestDb.class).table(NonDeserializableEntity.class)
+                        .readTable(defaultReadTableParamsNonLegacy())
+                        .collect(toList()))
         );
     }
 
 
     @Test
     public void resolveOnReadTableStream() {
-        db.tx(() -> {
+        tx.run(db -> {
             db.projects().save(new Project(new Project.Id("1"), "p1"));
             db.referrings().save(new Referring(new Referring.Id("1"), new Project.Id("1"), null, null, null));
             db.projects().save(new Project(new Project.Id("2"), "p2"));
@@ -2613,9 +2605,11 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
         });
 
-        db.readOnly().run(() ->
-                db.referrings().readTable(defaultReadTableParamsNonLegacy())
-                        .forEach(r -> db.projects().find(r.getProject()))
+        tx.readOnly().run(() ->
+                // FIXME
+                BaseDb.current(TestDb.class).referrings().readTable(defaultReadTableParamsNonLegacy())
+                        // FIXME
+                        .forEach(r -> BaseDb.current(TestDb.class).projects().find(r.getProject()))
         );
     }
 
@@ -2625,20 +2619,16 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 new WithUnflattenableField.Id("id42"),
                 new WithUnflattenableField.Unflattenable("Hello, world!", 100_500)
         );
-        db.tx(() -> db.table(WithUnflattenableField.class).insert(entity));
+        tx.run(db -> db.table(WithUnflattenableField.class).insert(entity));
 
-        db.tx(() -> {
-            assertThat(db.table(WithUnflattenableField.class).find(entity.getId())).isEqualTo(entity);
-        });
+        tx.run(db -> assertThat(db.table(WithUnflattenableField.class).find(entity.getId())).isEqualTo(entity));
     }
 
     @Test
     public void readFromCache() {
         Complex.Id id = new Complex.Id(1, 2L, "c", Complex.Status.OK);
-        db.tx(() -> {
-            db.complexes().insert(new Complex(id));
-        });
-        db.tx(() -> {
+        tx.run(db -> db.complexes().insert(new Complex(id)));
+        tx.run(db -> {
             Complex first = db.complexes().find(id);
             Complex second = db.complexes().find(id);
 
@@ -2649,8 +2639,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void findRangeAndPutInCache() {
-        db.tx(this::makeComplexes);
-        db.tx(() -> {
+        tx.run(this::makeComplexes);
+        tx.run(db -> {
             List<Complex> rangeResults = db.complexes().find(Range.create(new Complex.Id(0, 0L, null, null)));
             assertThat(rangeResults).hasSize(6);
 
@@ -2664,8 +2654,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void findAllAndPutInCache() {
-        db.tx(this::makeComplexes);
-        db.tx(() -> {
+        tx.run(this::makeComplexes);
+        tx.run(db -> {
             List<Complex> rangeResults = db.complexes().findAll();
             assertThat(rangeResults).hasSize(54);
 
@@ -2685,23 +2675,23 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         final Project.Id vaderId = new Project.Id("Vader");
 
         // But 'Always two there are', we consistently keep exactly 2 entities altogether:
-        Consumer<RepositoryTransaction> createFirstTwo = (tx) -> {
-            tx.table(Primitive.class).insert(new Primitive(sidiousId, 10));
-            tx.table(Complex.class).insert(new Complex(tyranusId));
+        Consumer<RepositoryTransaction> createFirstTwo = repositoryTransaction -> {
+            repositoryTransaction.table(Primitive.class).insert(new Primitive(sidiousId, 10));
+            repositoryTransaction.table(Complex.class).insert(new Complex(tyranusId));
         };
 
         // Do initial transaction:
         runInTx(createFirstTwo);
 
         // Prepare altering transaction as a hook that doesn't do anything in the second attempt.
-        Runnable concurrentChanger = makeOneShotRunnable(() -> db.separate().tx(() -> {
+        Runnable concurrentChanger = makeOneShotRunnable(() -> tx.separate().run(db -> {
             db.complexes().delete(tyranusId);
             db.projects().insert(new Project(vaderId, "abc"));
         }));
 
         List<Void> txAttempts = new ArrayList<>();
 
-        List<Entity<?>> twoElements = db.tx(() -> {
+        List<Entity<?>> twoElements = tx.call(db -> {
             txAttempts.add(null);
 
             db.table(Book.class).save(new Book(new Book.Id("1"), 1, "title1", List.of("author1")));
@@ -2739,32 +2729,32 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                     "payload-" + i,
                     Math.random() < 0.5 ? UpdateFeedEntry.Status.ACTIVE : UpdateFeedEntry.Status.INACTIVE
             );
-            db.tx(() -> db.updateFeedEntries().insert(snap));
+            tx.run(db -> db.updateFeedEntries().insert(snap));
             inserted.put(snap.getId(), snap);
         }
 
-        assertThat(db.tx(() -> db.updateFeedEntries().find(inserted.keySet())))
+        assertThatList(tx.call(db -> db.updateFeedEntries().find(inserted.keySet())))
                 .containsExactlyInAnyOrderElementsOf(inserted.values());
 
-        assertThat(db.tx(() -> db.updateFeedEntries().find(inserted.keySet())))
+        assertThatList(tx.call(db -> db.updateFeedEntries().find(inserted.keySet())))
                 .containsExactlyInAnyOrderElementsOf(inserted.values());
 
-        assertThat(db.tx(() -> db.updateFeedEntries().list(ListRequest.builder(UpdateFeedEntry.class)
+        assertThatIterable(tx.call(db -> db.updateFeedEntries().list(ListRequest.builder(UpdateFeedEntry.class)
                 .filter(fb -> fb.where("id").in(inserted.keySet()))
-                .build())))
-                .containsExactlyInAnyOrderElementsOf(inserted.values());
+                .build()))
+        ).containsExactlyInAnyOrderElementsOf(inserted.values());
 
-        assertThat(db.tx(() -> db.updateFeedEntries().list(ListRequest.builder(UpdateFeedEntry.class)
+        assertThatIterable(tx.call(db -> db.updateFeedEntries().list(ListRequest.builder(UpdateFeedEntry.class)
                 .filter(fb -> fb.where("id").in(inserted.keySet().stream().map(Object::toString).collect(toSet())))
-                .build())))
-                .containsExactlyInAnyOrderElementsOf(inserted.values());
+                .build()))
+        ).containsExactlyInAnyOrderElementsOf(inserted.values());
 
         for (var e : inserted.entrySet()) {
-            assertThat(db.tx(() -> db.updateFeedEntries().query()
+            assertThatObject(tx.call(db -> db.updateFeedEntries().query()
                     .filter(fb -> fb.where("id").eq(e.getKey()))
                     .findOne())).isEqualTo(e.getValue());
 
-            assertThat(db.tx(() -> db.updateFeedEntries().query()
+            assertThatObject(tx.call(db -> db.updateFeedEntries().query()
                     .filter(fb -> fb.where("id").eq(e.getKey().toString()))
                     .findOne())).isEqualTo(e.getValue());
         }
@@ -2778,26 +2768,26 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 new NetworkAppliance.Ipv6Address("2e:a0::1"),
                 new NetworkAppliance.SixtyFourBitString(Long.parseUnsignedLong("cafecafecafecafe", 16))
         );
-        db.tx(() -> db.networkAppliances().insert(app1));
-        assertThat(db.tx(() -> db.networkAppliances().find(app1.id()))).isEqualTo(app1);
+        tx.run(db -> db.networkAppliances().insert(app1));
+        assertThatObject(tx.call(db -> db.networkAppliances().find(app1.id()))).isEqualTo(app1);
     }
 
     @Test
     public void customValueTypeInFilter() {
         var ve = new VersionedEntity(new VersionedEntity.Id("heyhey", new Version(100L)), new Version(100_500L));
-        db.tx(() -> db.versionedEntities().insert(ve));
-        assertThat(db.tx(() -> db.versionedEntities().find(ve.id()))).isEqualTo(ve);
-        assertThat(db.tx(() -> db.versionedEntities().query()
+        tx.run(db -> db.versionedEntities().insert(ve));
+        assertThatObject(tx.call(db -> db.versionedEntities().find(ve.id()))).isEqualTo(ve);
+        assertThatObject(tx.call(db -> db.versionedEntities().query()
                 .where("id.version").eq(ve.id().version())
                 .and("version2").eq(ve.version2())
                 .findOne()
         )).isEqualTo(ve);
-        assertThat(db.tx(() -> db.versionedEntities().query()
+        assertThatObject(tx.call(db -> db.versionedEntities().query()
                 .where("id.version").eq(100L)
                 .and("version2").eq(100_500L)
                 .findOne()
         )).isEqualTo(ve);
-        assertThat(db.tx(() -> db.versionedEntities().query()
+        assertThatObject(tx.call(db -> db.versionedEntities().query()
                 .where("id.version").eq(100L)
                 .and("version2").eq(null)
                 .findOne()
@@ -2807,25 +2797,35 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void customValueTypeInFilterByAlias() {
         UUID testPrefferedUUID = UUID.randomUUID();
-        var ve = new VersionedAliasedEntity(new VersionedAliasedEntity.Id("heyhey", new Version(100L), testPrefferedUUID, new Sha256("100")), new Version(100_500L), testPrefferedUUID, new UniqueEntity.Id(testPrefferedUUID));
-        db.tx(() -> db.versionedAliasedEntities().insert(ve));
-        assertThat(db.tx(() -> db.versionedAliasedEntities().find(ve.id()))).isEqualTo(ve);
-        assertThat(db.tx(() -> db.versionedAliasedEntities().query()
+        var ve = new VersionedAliasedEntity(
+                new VersionedAliasedEntity.Id(
+                        "heyhey",
+                        new Version(100L),
+                        testPrefferedUUID,
+                        new Sha256("100")
+                ),
+                new Version(100_500L),
+                testPrefferedUUID,
+                new UniqueEntity.Id(testPrefferedUUID)
+        );
+        tx.run(db -> db.versionedAliasedEntities().insert(ve));
+        assertThatObject(tx.call(db -> db.versionedAliasedEntities().find(ve.id()))).isEqualTo(ve);
+        assertThatObject(tx.call(db -> db.versionedAliasedEntities().query()
                 .where("id.version").eq(ve.id().version())
                 .and("version2").eq(ve.version2())
                 .findOne()
         )).isEqualTo(ve);
-        assertThat(db.tx(() -> db.versionedAliasedEntities().query()
+        assertThatObject(tx.call(db -> db.versionedAliasedEntities().query()
                 .where("id.version").eq(100L)
                 .and("version2").eq(100_500L)
                 .findOne()
         )).isEqualTo(ve);
-        assertThat(db.tx(() -> db.versionedAliasedEntities().query()
+        assertThatObject(tx.call(db -> db.versionedAliasedEntities().query()
                 .where("id.version").eq(100L)
                 .and("version2").eq(null)
                 .findOne()
         )).isNull();
-        assertThat(db.tx(() -> db.versionedAliasedEntities().query()
+        assertThatObject(tx.call(db -> db.versionedAliasedEntities().query()
                 .where("uniqueId").eq(ve.uniqueId())
                 .findOne()
         )).isEqualTo(ve);
@@ -2836,15 +2836,15 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var uuid = UUID.randomUUID();
         var entity = new UniqueEntity(new UniqueEntity.Id(uuid), "hehe");
 
-        db.tx(() -> db.table(UniqueEntity.class).save(entity));
-        assertThat(db.tx(() -> db.table(UniqueEntity.class).find(new UniqueEntity.Id(uuid))))
+        tx.run(db -> db.table(UniqueEntity.class).save(entity));
+        assertThatObject(tx.call(db -> db.table(UniqueEntity.class).find(new UniqueEntity.Id(uuid))))
                 .isEqualTo(entity);
-        assertThat(db.tx(() -> db.table(UniqueEntity.class).query()
+        assertThatObject(tx.call(db -> db.table(UniqueEntity.class).query()
                 .where("id").eq(new UniqueEntity.Id(uuid))
                 .and("value").eq("hehe")
                 .findOne())
         ).isEqualTo(entity);
-        assertThat(db.tx(() -> db.table(UniqueEntity.class).query()
+        assertThatObject(tx.call(db -> db.table(UniqueEntity.class).query()
                 .where("id").eq(uuid)
                 .and("value").eq("hehe")
                 .findOne())
@@ -2856,15 +2856,15 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var uuid = UUID.randomUUID();
         var entity = new UniqueEntityNative(new UniqueEntityNative.Id(uuid), "hehe");
 
-        db.tx(() -> db.table(UniqueEntityNative.class).save(entity));
-        assertThat(db.tx(() -> db.table(UniqueEntityNative.class).find(new UniqueEntityNative.Id(uuid))))
+        tx.run(db -> db.table(UniqueEntityNative.class).save(entity));
+        assertThatObject(tx.call(db -> db.table(UniqueEntityNative.class).find(new UniqueEntityNative.Id(uuid))))
                 .isEqualTo(entity);
-        assertThat(db.tx(() -> db.table(UniqueEntityNative.class).query()
+        assertThatObject(tx.call(db -> db.table(UniqueEntityNative.class).query()
                 .where("id").eq(new UniqueEntityNative.Id(uuid))
                 .and("value").eq("hehe")
                 .findOne())
         ).isEqualTo(entity);
-        assertThat(db.tx(() -> db.table(UniqueEntityNative.class).query()
+        assertThatObject(tx.call(db -> db.table(UniqueEntityNative.class).query()
                 .where("id").eq(uuid)
                 .and("value").eq("hehe")
                 .findOne())
@@ -2874,8 +2874,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void detachedEntity() {
         var theEntity = new DetachedEntity(new DetachedEntityId("some-id"));
-        db.tx(() -> db.detachedEntities().save(theEntity));
-        assertThat(db.tx(() -> db.detachedEntities().find(theEntity.id()))).isEqualTo(theEntity);
+        tx.run(db -> db.detachedEntities().save(theEntity));
+        assertThatObject(tx.call(db -> db.detachedEntities().find(theEntity.id()))).isEqualTo(theEntity);
     }
 
     @Test
@@ -2885,14 +2885,14 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:013943912")
                 )
         ));
-        db.tx(() -> db.multiWrappedEntities2().save(theEntity));
+        tx.run(db -> db.multiWrappedEntities2().save(theEntity));
 
         var unwrapped = "xyzzy-central1:0";
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        assertThatObject(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").gt(unwrapped)
                 .findOne()
         )).isEqualTo(theEntity);
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        assertThatList(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").lt(unwrapped)
                 .find()
         )).isEmpty();
@@ -2905,14 +2905,14 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:013943912")
                 )
         ));
-        db.tx(() -> db.multiWrappedEntities2().save(theEntity));
+        tx.run(db -> db.multiWrappedEntities2().save(theEntity));
 
         var onceWrapped = MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:0");
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        assertThatObject(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").gt(onceWrapped)
                 .findOne()
         )).isEqualTo(theEntity);
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        assertThatList(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").lt(onceWrapped)
                 .find()
         )).isEmpty();
@@ -2925,14 +2925,16 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:013943912")
                 )
         ));
-        db.tx(() -> db.multiWrappedEntities2().save(theEntity));
+        tx.run(db -> db.multiWrappedEntities2().save(theEntity));
 
-        var twiceWrapped = new MultiWrappedEntity2.WrapperOfIdStringValue(MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:0"));
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        var twiceWrapped = new MultiWrappedEntity2.WrapperOfIdStringValue(
+                MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:0")
+        );
+        assertThatObject(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").gt(twiceWrapped)
                 .findOne()
         )).isEqualTo(theEntity);
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        assertThatList(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").lt(twiceWrapped)
                 .find()
         )).isEmpty();
@@ -2945,16 +2947,17 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                         MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:013943912")
                 )
         ));
-        db.tx(() -> db.multiWrappedEntities2().save(theEntity));
+        tx.run(db -> db.multiWrappedEntities2().save(theEntity));
 
         var schema = EntitySchema.of(MultiWrappedEntity2.class);
         var idField = schema.getField("id");
-        var sv = new StringFieldValue("xyzzy-central1:0").getRaw(idField); // Will get flattest original value, which is the IdStringValue("xyzzy-..")
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        // Will get flattest original value, which is the IdStringValue("xyzzy-..")
+        var sv = new StringFieldValue("xyzzy-central1:0").getRaw(idField);
+        assertThatObject(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").gt(sv)
                 .findOne()
         )).isEqualTo(theEntity);
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
+        assertThatList(tx.call(db -> db.multiWrappedEntities2().query()
                 .where("id").lt(sv)
                 .find()
         )).isEmpty();
@@ -2962,15 +2965,27 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     @Test
     public void multiWrapperEntity2WithCustomConverterFullyWrapped() {
-        var theEntity = new MultiWrappedEntity2(new MultiWrappedEntity2.Id(new MultiWrappedEntity2.WrapperOfIdStringValue(MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:013943912"))));
-        db.tx(() -> db.multiWrappedEntities2().save(theEntity));
+        var theEntity = new MultiWrappedEntity2(new MultiWrappedEntity2.Id(
+                new MultiWrappedEntity2.WrapperOfIdStringValue(
+                        MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:013943912")
+                )
+        ));
+        tx.run(db -> db.multiWrappedEntities2().save(theEntity));
 
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
-                .where("id").gt(new MultiWrappedEntity2.Id(new MultiWrappedEntity2.WrapperOfIdStringValue(MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:0"))))
+        assertThatObject(tx.call(db -> db.multiWrappedEntities2().query()
+                .where("id").gt(new MultiWrappedEntity2.Id(
+                        new MultiWrappedEntity2.WrapperOfIdStringValue(
+                                MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:0")
+                        )
+                ))
                 .findOne()
         )).isEqualTo(theEntity);
-        assertThat(db.tx(() -> db.multiWrappedEntities2().query()
-                .where("id").lt(new MultiWrappedEntity2.Id(new MultiWrappedEntity2.WrapperOfIdStringValue(MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:0"))))
+        assertThatList(tx.call(db -> db.multiWrappedEntities2().query()
+                .where("id").lt(new MultiWrappedEntity2.Id(
+                        new MultiWrappedEntity2.WrapperOfIdStringValue(
+                                MultiWrappedEntity2.IdStringValue.fromString("xyzzy-central1:0")
+                        )
+                ))
                 .find()
         )).isEmpty();
     }
@@ -2980,14 +2995,18 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         // must not be able to save a string-value field that returns null from toString()
         var badWrapperWithNullInside = new BadlyWrappedEntity(new BadlyWrappedEntity.Id("xxx"), new BadStringValueWrapper(null));
         assertThatExceptionOfType(ConversionException.class)
-                .isThrownBy(() -> db.tx(() -> db.table(BadlyWrappedEntity.class).save(badWrapperWithNullInside)))
+                .isThrownBy(() -> tx.run(db -> db.table(BadlyWrappedEntity.class).save(badWrapperWithNullInside)))
                 .withCauseInstanceOf(IllegalArgumentException.class);
 
         // null column value -> null string-value type field, without invoking the converter at all
         var noWrapper = new BadlyWrappedEntity(new BadlyWrappedEntity.Id("yyy"), null);
-        db.tx(() -> db.table(BadlyWrappedEntity.class).save(noWrapper));
-        assertThat(db.tx(() -> db.table(BadlyWrappedEntity.class).find(new BadlyWrappedEntity.Id("yyy"))).badWrapper()).isNull();
-        assertThat(db.tx(() -> db.table(BadlyWrappedEntity.class).find(new BadlyWrappedEntity.Id("yyy")))).isEqualTo(noWrapper);
+        tx.call(db -> db.table(BadlyWrappedEntity.class).save(noWrapper));
+        assertThatObject(
+                tx.call(db -> db.table(BadlyWrappedEntity.class).find(new BadlyWrappedEntity.Id("yyy"))).badWrapper()
+        ).isNull();
+        assertThatObject(
+                tx.call(db -> db.table(BadlyWrappedEntity.class).find(new BadlyWrappedEntity.Id("yyy")))
+        ).isEqualTo(noWrapper);
     }
 
     @Test
@@ -3021,17 +3040,17 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var entity1 = new EnumEntity(new EnumEntity.Id("qee1"), EnumEntity.IpVersion.IPV6, EnumEntity.NetworkType.OVERLAY);
         var entity2 = new EnumEntity(new EnumEntity.Id("qee2"), EnumEntity.IpVersion.IPV4, EnumEntity.NetworkType.UNDERLAY_V4);
         var entity3 = new EnumEntity(new EnumEntity.Id("qee3"), EnumEntity.IpVersion.IPV6, EnumEntity.NetworkType.UNDERLAY_V6);
-        db.tx(() -> db.table(EnumEntity.class).insert(entity1, entity2, entity3));
-        db.tx(() -> db.table(EnumEntity.class).update(entity2.id(), new Changeset()
+        tx.run(db -> db.table(EnumEntity.class).insert(entity1, entity2, entity3));
+        tx.run(db -> db.table(EnumEntity.class).update(entity2.id(), new Changeset()
                 .set("ipVersion", "ipv4") // the lowercase of IPV4.name(), which IS allowed by the LENIENT enum deserializer
                 .set("networkType", "underlay-v4") // this uses toString() to convert enums, and "underlay-v4" corresponds to a UNDERLAY_V4 constant
         ));
-        db.tx(() -> db.table(EnumEntity.class).update(entity3.id(), new Changeset()
+        tx.run(db -> db.table(EnumEntity.class).update(entity3.id(), new Changeset()
                 .set("ipVersion", "IPV5") // mwahahahahah! This is an unknown constant which the LENIENT enum deserializer will turn into null (!!)
                 .set("networkType", "zz") // same here!!!
         ));
 
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.table(EnumEntity.class).find(entity1.id())).isEqualTo(entity1);
 
             // lowercase 'ipv4' treated as 'IPV4' constant
@@ -3046,21 +3065,21 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
         var entity2 = new EnumEntity(new EnumEntity.Id("qee2"), EnumEntity.IpVersion.IPV4, EnumEntity.NetworkType.UNDERLAY_V4);
         var entity3 = new EnumEntity(new EnumEntity.Id("qee3"), EnumEntity.IpVersion.IPV4, EnumEntity.NetworkType.UNDERLAY_V4);
         var entity4 = new EnumEntity(new EnumEntity.Id("qee4"), EnumEntity.IpVersion.IPV6, EnumEntity.NetworkType.UNDERLAY_V6);
-        db.tx(() -> db.table(EnumEntity.class).insert(entity1, entity2, entity3, entity4));
-        db.tx(() -> db.table(EnumEntity.class).update(entity2.id(), new Changeset()
+        tx.run(db -> db.table(EnumEntity.class).insert(entity1, entity2, entity3, entity4));
+        tx.run(db -> db.table(EnumEntity.class).update(entity2.id(), new Changeset()
                 .set("ipVersion", "IPV4") // IPV4.name(), verbatim
                 .set("networkType", "underlay-v4") // this uses toString() to convert enums, and "underlay-v4" corresponds to a UNDERLAY_V4 constant
         ));
-        db.tx(() -> db.table(EnumEntity.class).update(entity3.id(), new Changeset()
+        tx.run(db -> db.table(EnumEntity.class).update(entity3.id(), new Changeset()
                 .set("ipVersion", "ipv4") // the lowercase of IPV4.name(), which IS NOT allowed by the STRICT enum deserializer
                 .set("networkType", "underlay-v4") // this uses toString() to convert enums, and "underlay-v4" corresponds to a UNDERLAY_V4 constant
         ));
-        db.tx(() -> db.table(EnumEntity.class).update(entity4.id(), new Changeset()
+        tx.run(db -> db.table(EnumEntity.class).update(entity4.id(), new Changeset()
                 .set("ipVersion", "IPV5") // mwahahahahah! This is an unknown constant which the STRICT enum deserializer disallows (!!)
                 .set("networkType", "zz") // same here!!!
         ));
 
-        db.tx(() -> {
+        tx.run(db -> {
             assertThat(db.table(EnumEntity.class).find(entity1.id())).isEqualTo(entity1);
             assertThat(db.table(EnumEntity.class).find(entity2.id())).isEqualTo(entity2);
 
@@ -3074,7 +3093,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
     @Test
     public void postLoadAndPreSave() {
         var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        db.tx(() -> {
+        tx.run(db -> {
             var table = db.table(MigrationEntity.class);
             var saved = table.save(new MigrationEntity(new MigrationEntity.Id("id"), null, null));
             assertThat(saved).isEqualTo(new MigrationEntity(new MigrationEntity.Id("id"), null, Instant.EPOCH));
@@ -3089,7 +3108,7 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
             assertThat(inserted2).isEqualTo(new MigrationEntity(new MigrationEntity.Id("iid2"), "Hello, world!", now));
         });
 
-        db.tx(() -> {
+        tx.run(db -> {
             var table = db.table(MigrationEntity.class);
             assertThat(table.find(new MigrationEntity.Id("id")))
                     .isEqualTo(new MigrationEntity(new MigrationEntity.Id("id"), "Default Value", Instant.EPOCH));
@@ -3101,11 +3120,11 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                     .isEqualTo(new MigrationEntity(new MigrationEntity.Id("iid2"), "Hello, world!", now));
         });
 
-        db.tx(() -> {
+        tx.run(db -> {
             var table = db.table(MigrationEntity.class);
             table.update(new MigrationEntity.Id("id"), Changeset.setField("fillOnPreSave", null));
         });
-        db.tx(() -> {
+        tx.run(db -> {
             var table = db.table(MigrationEntity.class);
             assertThat(table.find(new MigrationEntity.Id("id")))
                     .isEqualTo(new MigrationEntity(new MigrationEntity.Id("id"), "Default Value", null));
@@ -3224,14 +3243,14 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
 
     protected void runInTx(Consumer<RepositoryTransaction> action) {
         // We do not retry transactions, because we do not expect conflicts in our test scenarios.
-        RepositoryTransaction transaction = startTransaction();
+        RepositoryTransaction repositoryTransaction = startTransaction();
         try {
-            action.accept(transaction);
+            action.accept(repositoryTransaction);
         } catch (Throwable t) {
-            transaction.rollback();
+            repositoryTransaction.rollback();
             throw t;
         }
-        transaction.commit();
+        repositoryTransaction.commit();
     }
 
     private void assertListingContains(FilterExpression<Project> filterExpression, Project... expectedProjects) {
@@ -3239,7 +3258,8 @@ public abstract class RepositoryTest extends RepositoryTestSupport {
                 .filter(filterExpression)
                 .build();
 
-        ListResult<Project> result = db.readOnly().run(() -> db.projects().list(request));
+        // FIXME
+        ListResult<Project> result = tx.readOnly().run(() -> BaseDb.current(TestDb.class).projects().list(request));
         assertThat(result.getEntries()).containsExactlyInAnyOrder(expectedProjects);
     }
 

--- a/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/TestDb.java
+++ b/repository-test/src/main/java/tech/ydb/yoj/repository/test/sample/TestDb.java
@@ -1,6 +1,4 @@
 package tech.ydb.yoj.repository.test.sample;
 
-import tech.ydb.yoj.repository.db.TxManager;
-
-public interface TestDb extends TxManager, TestEntityOperations {
+public interface TestDb extends TestEntityOperations {
 }

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/list/YdbListingIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/list/YdbListingIntegrationTest.java
@@ -32,7 +32,7 @@ public class YdbListingIntegrationTest extends ListingTest {
         Complex c2 = new Complex(new Complex.Id(999_999, 15L, "UUU", Complex.Status.OK));
         Complex c3 = new Complex(new Complex.Id(999_999, 15L, "KKK", Complex.Status.OK));
         Complex c4 = new Complex(new Complex.Id(999_000, 15L, "AAA", Complex.Status.OK));
-        db.tx(() -> db.complexes().insert(c1, c2, c3, c4));
+        tx.run(db -> db.complexes().insert(c1, c2, c3, c4));
 
         FilterExpression<Complex> filter = newFilterBuilder(Complex.class).where("id.b").eq(15L).and("id.a").eq(999_999).build();
         ListRequest<Complex> listRequest = ListRequest.builder(Complex.class).pageSize(3).filter(filter).build();
@@ -40,8 +40,8 @@ public class YdbListingIntegrationTest extends ListingTest {
         YqlPredicate predicate = YqlListingQuery.toYqlPredicate(filter);
         assertThat(predicate.toYql(EntitySchema.of(Complex.class))).isEqualTo("(`id_a` = ?) AND (`id_b` = ?)");
 
-        db.tx(() -> {
-            ListResult<Complex> page = listComplex(listRequest);
+        tx.run(db -> {
+            ListResult<Complex> page = db.complexes().list(listRequest);
             assertThat(page).containsExactly(c3, c2, c1);
             assertThat(page.isLastPage()).isTrue();
         });

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/merge/YqlQueryMergerIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/merge/YqlQueryMergerIntegrationTest.java
@@ -3,10 +3,10 @@ package tech.ydb.yoj.repository.ydb.merge;
 import org.junit.ClassRule;
 import org.junit.Test;
 import tech.ydb.yoj.repository.db.Repository;
+import tech.ydb.yoj.repository.db.ScopedTxManager;
 import tech.ydb.yoj.repository.test.RepositoryTestSupport;
 import tech.ydb.yoj.repository.test.entity.TestEntities;
 import tech.ydb.yoj.repository.test.sample.TestDb;
-import tech.ydb.yoj.repository.test.sample.TestDbImpl;
 import tech.ydb.yoj.repository.test.sample.model.Project;
 import tech.ydb.yoj.repository.ydb.TestYdbRepository;
 import tech.ydb.yoj.repository.ydb.YdbEnvAndTransportRule;
@@ -20,17 +20,17 @@ public class YqlQueryMergerIntegrationTest extends RepositoryTestSupport {
     @ClassRule
     public static final YdbEnvAndTransportRule ydbEnvAndTransport = new YdbEnvAndTransportRule();
 
-    protected TestDb db;
+    protected ScopedTxManager<TestDb> tx;
 
     @Override
     public void setUp() {
         super.setUp();
-        this.db = new TestDbImpl<>(this.repository);
+        this.tx = new ScopedTxManager<>(this.repository, TestDb.class);
     }
 
     @Override
     public void tearDown() {
-        this.db = null;
+        this.tx = null;
         super.tearDown();
     }
 
@@ -41,7 +41,7 @@ public class YqlQueryMergerIntegrationTest extends RepositoryTestSupport {
 
     @Test
     public void insertAfterFindByIdWorks() {
-        db.tx(() -> {
+        tx.run(db -> {
             Project.Id id = new Project.Id(RandomUtils.nextString(10));
 
             assertThat(db.projects().find(id)).isNull();

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/DelegatingTxManager.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/DelegatingTxManager.java
@@ -18,10 +18,13 @@ import static lombok.AccessLevel.PRIVATE;
  * doRunTx()}</li>
  * </ul>
  *
+ * @param <SELF> This class's type. This allows to have {@code TxManager} configuration calls return specific subtype
+ *               instead of just {@code TxManager}
+ *
  * @see #wrapTxBody(Supplier)
  * @see #doRunTx(Supplier)
  */
-public abstract class DelegatingTxManager implements TxManager {
+public abstract class DelegatingTxManager<SELF extends DelegatingTxManager<SELF>> implements TxManager {
     protected final TxManager delegate;
 
     protected DelegatingTxManager(@NonNull TxManager delegate) {
@@ -61,7 +64,7 @@ public abstract class DelegatingTxManager implements TxManager {
      * @param delegate transaction manager to delegate to
      * @return wrapped {@code delegate}
      */
-    protected abstract TxManager createTxManager(TxManager delegate);
+    protected abstract SELF createTxManager(TxManager delegate);
 
     @Override
     public final void tx(Runnable runnable) {
@@ -77,102 +80,102 @@ public abstract class DelegatingTxManager implements TxManager {
     }
 
     @Override
-    public final TxManager withName(String name, String logContext) {
+    public final SELF withName(String name, String logContext) {
         return createTxManager(this.delegate.withName(name, logContext));
     }
 
     @Override
-    public final TxManager withName(String name) {
+    public final SELF withName(String name) {
         return createTxManager(this.delegate.withName(name));
     }
 
     @Override
-    public final TxManager withLogContext(String logContext) {
+    public final SELF withLogContext(String logContext) {
         return createTxManager(this.delegate.withLogContext(logContext));
     }
 
     @Override
-    public final TxManager separate() {
+    public final SELF separate() {
         return createTxManager(this.delegate.separate());
     }
 
     @Override
-    public TxManager delayedWrites() {
+    public final SELF delayedWrites() {
         return createTxManager(this.delegate.delayedWrites());
     }
 
     @Override
-    public final TxManager immediateWrites() {
+    public final SELF immediateWrites() {
         return createTxManager(this.delegate.immediateWrites());
     }
 
     @Override
-    public final TxManager noFirstLevelCache() {
+    public final SELF noFirstLevelCache() {
         return createTxManager(this.delegate.noFirstLevelCache());
     }
 
     @Override
-    public final TxManager failOnUnknownSeparateTx() {
+    public final SELF failOnUnknownSeparateTx() {
         return createTxManager(this.delegate.failOnUnknownSeparateTx());
     }
 
     @Override
-    public final TxManager withMaxRetries(int maxRetries) {
+    public final SELF withMaxRetries(int maxRetries) {
         return createTxManager(this.delegate.withMaxRetries(maxRetries));
     }
 
     @Override
-    public final TxManager withDryRun(boolean dryRun) {
+    public final SELF withDryRun(boolean dryRun) {
         return createTxManager(this.delegate.withDryRun(dryRun));
     }
 
     @Override
-    public final TxManager withLogLevel(TransactionLog.Level level) {
+    public final SELF withLogLevel(TransactionLog.Level level) {
         return createTxManager(this.delegate.withLogLevel(level));
     }
 
     @Override
-    public final TxManager withLogStatementOnSuccess(boolean logStatementOnSuccess) {
+    public final SELF withLogStatementOnSuccess(boolean logStatementOnSuccess) {
         return createTxManager(this.delegate.withLogStatementOnSuccess(logStatementOnSuccess));
     }
 
     @Override
-    public final TxManager withTimeout(@NonNull Duration timeout) {
+    public final SELF withTimeout(@NonNull Duration timeout) {
         return createTxManager(this.delegate.withTimeout(timeout));
     }
 
     @Override
-    public final TxManager withQueryStats(@NonNull QueryStatsMode queryStats) {
+    public final SELF withQueryStats(@NonNull QueryStatsMode queryStats) {
         return createTxManager(this.delegate.withQueryStats(queryStats));
     }
 
     @Override
-    public TxManager withFullQueryTracing() {
+    public final SELF withFullQueryTracing() {
         return createTxManager(this.delegate.withFullQueryTracing());
     }
 
     @Override
-    public TxManager noQueryTracing() {
+    public final SELF noQueryTracing() {
         return createTxManager(this.delegate.noQueryTracing());
     }
 
     @Override
-    public TxManager withTracingFilter(@NonNull QueryTracingFilter tracingFilter) {
+    public final SELF withTracingFilter(@NonNull QueryTracingFilter tracingFilter) {
         return createTxManager(this.delegate.withTracingFilter(tracingFilter));
     }
 
     @Override
-    public final TxManager withVerboseLogging() {
+    public final SELF withVerboseLogging() {
         return createTxManager(this.delegate.withVerboseLogging());
     }
 
     @Override
-    public final TxManager withBriefLogging() {
+    public final SELF withBriefLogging() {
         return createTxManager(this.delegate.withBriefLogging());
     }
 
     @Override
-    public final TxManager noLogging() {
+    public final SELF noLogging() {
         return createTxManager(this.delegate.noLogging());
     }
 

--- a/repository/src/main/java/tech/ydb/yoj/repository/db/ScopedTxManager.java
+++ b/repository/src/main/java/tech/ydb/yoj/repository/db/ScopedTxManager.java
@@ -1,0 +1,49 @@
+package tech.ydb.yoj.repository.db;
+
+import lombok.NonNull;
+import tech.ydb.yoj.ExperimentalApi;
+import tech.ydb.yoj.repository.BaseDb;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/197")
+public final class ScopedTxManager<D extends BaseDb> extends DelegatingTxManager<ScopedTxManager<D>> {
+    private final D db;
+
+    public ScopedTxManager(@NonNull Repository repository, @NonNull Class<D> dbClass) {
+        this(new StdTxManager(repository), dbClass);
+    }
+
+    public ScopedTxManager(@NonNull TxManager delegate, @NonNull Class<D> dbClass) {
+        this(delegate, BaseDb.current(dbClass));
+    }
+
+    private ScopedTxManager(@NonNull TxManager delegate, @NonNull D db) {
+        super(delegate);
+        this.db = db;
+    }
+
+    public <R> R call(@NonNull Function<D, R> function) {
+        return tx(() -> function.apply(db));
+    }
+
+    public <T> T call(@NonNull BiFunction<D, Tx, T> function) {
+        return tx(() -> function.apply(db, Tx.Current.get()));
+    }
+
+    public void run(@NonNull Consumer<D> consumer) {
+        tx(() -> consumer.accept(db));
+    }
+
+    public void run(@NonNull BiConsumer<D, Tx> consumer) {
+        tx(() -> consumer.accept(db, Tx.Current.get()));
+    }
+
+    @Override
+    protected ScopedTxManager<D> createTxManager(TxManager delegate) {
+        return new ScopedTxManager<>(delegate, this.db);
+    }
+}


### PR DESCRIPTION
Very very experimental atm. Problems:
- Not especially nice to use compared to @Inject'ing your Db implementation (that is just BaseDb.current()) /Using BaseDb.current() directly.
- Function<Db, R> and Consumer<Db> are lambda signature-compatible, this leads to unability to have the same tx() name for both methods, and we get ScopedTxManager.call() and ScopedTxManager.run(), which is sub-optimal
- Even if we only have one Function<Db,R>-taking method in ScopedManager, we get generics hell with AssertJ's assertThat(): results of Function<Db,R>-taking method are considered by javac to be compatible with almost every interface argument that assertThat() takes!
- ReadOnlyBuilder/ScanBuilder are not supported (yet)