### PR TITLE
#165: Make YdbValidator implementation customizable via YdbRepository settings

### DIFF
--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/SessionClient.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/SessionClient.java
@@ -27,7 +27,9 @@ import tech.ydb.yoj.util.lang.Exceptions;
         this.schemeClient = SchemeClient.newClient(transport).build();
         this.topicClient = TopicClient.newClient(transport).build();
 
-        this.sessionManager = new YdbSessionManager(tableClient, config.getSessionCreationTimeout());
+        this.sessionManager = new YdbSessionManager(
+                tableClient, repositorySettings.ydbValidator(), config.getSessionCreationTimeout()
+        );
         this.schemaOperations = new YdbSchemaOperations(
                 config.getTablespace(), sessionManager, schemeClient, topicClient
         );

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbOperations.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbOperations.java
@@ -1,12 +1,17 @@
 package tech.ydb.yoj.repository.ydb;
 
+import io.grpc.Context;
+import lombok.NonNull;
 import tech.ydb.yoj.InternalApi;
+import tech.ydb.yoj.repository.db.exception.DeadlineExceededException;
 import tech.ydb.yoj.repository.db.exception.InternalRepositoryException;
+import tech.ydb.yoj.repository.db.exception.QueryCancelledException;
 import tech.ydb.yoj.repository.db.exception.QueryInterruptedException;
 import tech.ydb.yoj.repository.db.exception.RepositoryException;
 import tech.ydb.yoj.repository.db.exception.UnavailableException;
 import tech.ydb.yoj.repository.ydb.exception.YdbRepositoryException;
 
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -15,7 +20,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static tech.ydb.yoj.repository.ydb.client.YdbValidator.checkGrpcDeadlineAndCancellation;
 import static tech.ydb.yoj.util.lang.Interrupts.isThreadInterrupted;
 
 @InternalApi
@@ -61,5 +65,30 @@ public final class YdbOperations {
         } else {
             return new InternalRepositoryException(ex);
         }
+    }
+
+    /**
+     * Checks current GRPC context for timeout and cancellation, and throws an appropriate {@code RepositoryException}
+     * if the context indeed timed out or was cancelled.
+     *
+     * @param errorMessage error message from the database; might be {@code null}
+     * @param cause        an exception that caused the timeout and cancellation check; might be {@code null}
+     * @throws DeadlineExceededException Deadline for current GRPC request context was exceeded
+     * @throws QueryCancelledException   Current GRPC request context was cancelled
+     */
+    public static void checkGrpcDeadlineAndCancellation(@Nullable String errorMessage, @Nullable Throwable cause) {
+        Context ctx = Context.current();
+        if (ctx.getDeadline() != null && ctx.getDeadline().isExpired()) {
+            // GRPC deadline for the current GRPC context has expired. We need to throw a separate exception to avoid retries
+            throw new DeadlineExceededException("DB query deadline exceeded" + responseToString(errorMessage), cause);
+        } else if (ctx.isCancelled()) {
+            // Client has cancelled the GRPC request. Throw a separate exception to avoid retries
+            throw new QueryCancelledException("DB query cancelled" + responseToString(errorMessage));
+        }
+    }
+
+    @NonNull
+    private static String responseToString(@Nullable String response) {
+        return response == null ? "" : ". Response from DB: " + response;
     }
 }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepository.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepository.java
@@ -26,6 +26,7 @@ import tech.ydb.yoj.repository.db.TxOptions;
 import tech.ydb.yoj.repository.ydb.client.SessionManager;
 import tech.ydb.yoj.repository.ydb.client.YdbSchemaOperations;
 import tech.ydb.yoj.repository.ydb.client.YdbTableHint;
+import tech.ydb.yoj.repository.ydb.client.YdbValidator;
 import tech.ydb.yoj.repository.ydb.compatibility.YdbDataCompatibilityChecker;
 import tech.ydb.yoj.repository.ydb.compatibility.YdbSchemaCompatibilityChecker;
 import tech.ydb.yoj.repository.ydb.statement.Statement;
@@ -50,6 +51,7 @@ import static tech.ydb.yoj.repository.ydb.client.YdbPaths.canonicalDatabase;
 public class YdbRepository implements Repository {
     private static final Logger log = LoggerFactory.getLogger(YdbRepository.class);
 
+    private final Settings settings;
     private final GrpcTransport transport;
     private final CloseableMemoizer<SessionClient> sessionClient;
 
@@ -100,6 +102,7 @@ public class YdbRepository implements Repository {
     ) {
         this.entityClassesByTableName = new ConcurrentHashMap<>();
         this.transport = transport;
+        this.settings = repositorySettings;
         this.sessionClient = MoreSuppliers.memoizeCloseable(
                 () -> new SessionClient(config, repositorySettings, transport)
         );
@@ -328,6 +331,11 @@ public class YdbRepository implements Repository {
         };
     }
 
+    @NonNull
+    public YdbValidator getYdbValidator() {
+        return settings.ydbValidator();
+    }
+
     @Value
     public static class Query<PARAMS> {
         Statement<PARAMS, ?> statement;
@@ -353,17 +361,20 @@ public class YdbRepository implements Repository {
      *                            In YOJ 3.x, the {@link QueryImplementation.QueryService YDB QueryService} will become
      *                            the default.
      * @param metrics             Metrics configuration
+     * @param ydbValidator        Mapper from YDB {@code Status}es into {@code RepositoryException}s
      */
     @With
     @Builder(builderMethodName = "")
     public record Settings(
             @NonNull QueryImplementation queryImplementation,
-            @NonNull Metrics metrics
+            @NonNull Metrics metrics,
+            @NonNull YdbValidator ydbValidator
     ) {
         public static SettingsBuilder builder() {
             return new SettingsBuilder()
                     .queryImplementation(new QueryImplementation.TableService())
-                    .metrics(Metrics.builder().build());
+                    .metrics(Metrics.builder().build())
+                    .ydbValidator(YdbValidator.DEFAULT);
         }
 
         /**

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbRepositoryTransaction.java
@@ -91,20 +91,22 @@ import static lombok.AccessLevel.PRIVATE;
 
 public class YdbRepositoryTransaction<REPO extends YdbRepository>
         implements BaseDb, RepositoryTransaction, YdbTable.QueryExecutor {
+    public static final String REQUEST_COMMIT = "commit";
+    public static final String REQUEST_ROLLBACK = "rollback";
+
     private static final Logger log = LoggerFactory.getLogger(YdbRepositoryTransaction.class);
 
     private static final String PROP_TRACE_DUMP_YDB_PARAMS = "tech.ydb.yoj.repository.ydb.trace.dumpYdbParams";
     private static final String PROP_TRACE_VERBOSE_OBJ_PARAMS = "tech.ydb.yoj.repository.ydb.trace.verboseObjParams";
     private static final String PROP_TRACE_VERBOSE_OBJ_RESULTS = "tech.ydb.yoj.repository.ydb.trace.verboseObjResults";
 
-    private static final String CLOSE_ACTION_ROLLBACK = "rollback";
-    private static final String CLOSE_ACTION_COMMIT = "commit";
-
     private static final Duration DEFAULT_SPLITERATOR_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration ADDED_SPLITERATOR_TIMEOUT = Duration.ofMinutes(1);
 
     private final List<YdbRepository.Query<?>> pendingWrites = new ArrayList<>();
     private final List<YdbSpliterator<?>> spliterators = new ArrayList<>();
+
+    private final YdbValidator ydbValidator;
 
     @Getter
     private final TxOptions options;
@@ -128,13 +130,14 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
         this.transactionLocal = new TransactionLocal(options);
         this.cache = options.isFirstLevelCache() ? RepositoryCache.create() : RepositoryCache.empty();
         this.tablespace = repo.getSchemaOperations().getTablespace();
+        this.ydbValidator = repo.getYdbValidator();
     }
 
     private <V> YdbSpliterator<V> createSpliterator(String request, boolean isOrdered, @Nullable Duration readTimeout) {
         Duration spliteratorTimeout = readTimeout == null
                 ? DEFAULT_SPLITERATOR_TIMEOUT
                 : readTimeout.plus(ADDED_SPLITERATOR_TIMEOUT);
-        YdbSpliterator<V> spliterator = new YdbSpliterator<>(request, isOrdered, spliteratorTimeout);
+        YdbSpliterator<V> spliterator = new YdbSpliterator<>(request, ydbValidator, isOrdered, spliteratorTimeout);
         spliterators.add(spliterator);
         return spliterator;
     }
@@ -160,16 +163,16 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
             rollback();
             throw t;
         }
-        endTransaction(CLOSE_ACTION_COMMIT, this::doCommit);
+        endTransaction(REQUEST_COMMIT, this::doCommit);
     }
 
     @Override
     public void rollback() {
         Interrupts.runInCleanupMode(() -> {
             try {
-                endTransaction(CLOSE_ACTION_ROLLBACK, () -> {
+                endTransaction(REQUEST_ROLLBACK, () -> {
                     Status status = YdbOperations.safeJoin(session.rollbackTransaction(txId, new RollbackTxSettings()));
-                    validate(CLOSE_ACTION_ROLLBACK, status, status.toString());
+                    validate(REQUEST_ROLLBACK, status, status.toString());
                 });
             } catch (Throwable t) {
                 log.info("Failed to rollback the transaction", t);
@@ -180,7 +183,7 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
     private void doCommit() {
         try {
             Status status = YdbOperations.safeJoin(session.commitTransaction(txId, new CommitTxSettings()));
-            validate(CLOSE_ACTION_COMMIT, status, status.toString());
+            validate(REQUEST_COMMIT, status, status.toString());
         } catch (YdbComponentUnavailableException | YdbOverloadedException e) {
             throw new UnavailableException("Unknown transaction state: commit was sent, but result is unknown", e);
         }
@@ -207,10 +210,10 @@ public class YdbRepositoryTransaction<REPO extends YdbRepository>
 
     private void validate(String request, Status status, String response) {
         if (!isBadSession) {
-            isBadSession = YdbValidator.isTransactionClosedByServer(status);
+            isBadSession = ydbValidator.isTransactionClosedByServer(status);
         }
         try {
-            YdbValidator.validate(request, status, response);
+            ydbValidator.validate(request, status, response);
         } catch (BadSessionException | OptimisticLockException e) {
             transactionLocal.log().info("Request got %s: DB tx was invalidated", e.getClass().getSimpleName());
             throw e;

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/YdbSpliterator.java
@@ -8,6 +8,7 @@ import tech.ydb.yoj.ExperimentalApi;
 import tech.ydb.yoj.InternalApi;
 import tech.ydb.yoj.repository.db.exception.DeadlineExceededException;
 import tech.ydb.yoj.repository.db.exception.QueryInterruptedException;
+import tech.ydb.yoj.repository.ydb.client.YdbValidator;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
@@ -16,13 +17,12 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static tech.ydb.yoj.repository.ydb.client.YdbValidator.validate;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * {@code YdbSpliterator} used to read data from YDB streams.
@@ -55,19 +55,19 @@ public class YdbSpliterator<V> implements Spliterator<V> {
 
     private boolean endData = false;
 
-    public YdbSpliterator(String request, boolean isOrdered, Duration streamWorkTimeout) {
+    public YdbSpliterator(String request, YdbValidator ydbValidator, boolean isOrdered, Duration streamWorkTimeout) {
         this.flags = (isOrdered ? ORDERED : 0) | NONNULL;
-        this.streamWorkDeadlineNanos = System.nanoTime() + TimeUnit.NANOSECONDS.toNanos(saturatedToNanos(streamWorkTimeout));
+        this.streamWorkDeadlineNanos = System.nanoTime() + NANOSECONDS.toNanos(saturatedToNanos(streamWorkTimeout));
         this.validateResponse = (status, error) -> {
             if (error != null) {
                 throw YdbOperations.convertToRepositoryException(error);
             }
-            validate(request, status, status.toString());
+            ydbValidator.validate(request, status, status.toString());
         };
     }
 
     private long calculateTimeout() {
-        return TimeUnit.NANOSECONDS.toNanos(streamWorkDeadlineNanos - System.nanoTime());
+        return NANOSECONDS.toNanos(streamWorkDeadlineNanos - System.nanoTime());
     }
 
     // Correct way to create stream with YdbSpliterator. onClose call is important for avoid supplier thread leak.
@@ -84,7 +84,7 @@ public class YdbSpliterator<V> implements Spliterator<V> {
         }
 
         try {
-            if (!queue.offer(QueueValue.of(value), calculateTimeout(), TimeUnit.NANOSECONDS)) {
+            if (!queue.offer(QueueValue.of(value), calculateTimeout(), NANOSECONDS)) {
                 log.warn("Supplier thread was closed because consumer didn't poll an element of stream on timeout");
                 throw OfferDeadlineExceededException.INSTANCE;
             }
@@ -116,7 +116,7 @@ public class YdbSpliterator<V> implements Spliterator<V> {
     @Nullable
     private QueueValue<V> poll() {
         try {
-            return queue.poll(calculateTimeout(), TimeUnit.NANOSECONDS);
+            return queue.poll(calculateTimeout(), NANOSECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new QueryInterruptedException("Consumer thread interrupted", e);
@@ -229,8 +229,8 @@ public class YdbSpliterator<V> implements Spliterator<V> {
         try {
             while (true) {
                 try {
-                    long timeout = TimeUnit.NANOSECONDS.toNanos(deadlineNanos - System.nanoTime());
-                    return queue.offer(element, timeout, TimeUnit.NANOSECONDS);
+                    long timeout = NANOSECONDS.toNanos(deadlineNanos - System.nanoTime());
+                    return queue.offer(element, timeout, NANOSECONDS);
                 } catch (InterruptedException ignore) {
                     interrupted = true;
                 }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSessionManager.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbSessionManager.java
@@ -1,5 +1,6 @@
 package tech.ydb.yoj.repository.ydb.client;
 
+import lombok.NonNull;
 import tech.ydb.core.Result;
 import tech.ydb.table.Session;
 import tech.ydb.table.TableClient;
@@ -14,17 +15,24 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
+import static tech.ydb.yoj.repository.ydb.YdbOperations.checkGrpcDeadlineAndCancellation;
 import static tech.ydb.yoj.util.lang.Interrupts.isThreadInterrupted;
 
 @InternalApi
 public final class YdbSessionManager implements SessionManager {
-    private static final String REQUEST_GET_SESSION = "getSession";
+    public static final String REQUEST_GET_SESSION = "getSession";
 
     private final TableClient tableClient;
     private final Duration sessionTimeout;
+    private final YdbValidator ydbValidator;
 
-    public YdbSessionManager(TableClient tableClient, Duration sessionCreationTimeout) {
+    public YdbSessionManager(
+            @NonNull TableClient tableClient,
+            @NonNull YdbValidator ydbValidator,
+            @NonNull Duration sessionCreationTimeout
+    ) {
         this.tableClient = tableClient;
+        this.ydbValidator = ydbValidator;
         this.sessionTimeout = getSessionTimeout(sessionCreationTimeout);
     }
 
@@ -33,7 +41,7 @@ public final class YdbSessionManager implements SessionManager {
         CompletableFuture<Result<Session>> future = tableClient.createSession(sessionTimeout);
         try {
             Result<Session> result = future.get();
-            YdbValidator.validate(REQUEST_GET_SESSION, result.getStatus(), result.toString());
+            ydbValidator.validate(REQUEST_GET_SESSION, result.getStatus(), result.toString());
             return result.getValue();
         } catch (CancellationException | CompletionException | ExecutionException | InterruptedException e) {
             // We need to cancel the future, otherwise we can get a session leak
@@ -43,7 +51,7 @@ public final class YdbSessionManager implements SessionManager {
                 Thread.currentThread().interrupt();
                 throw new QueryInterruptedException("get session interrupted", e);
             }
-            YdbValidator.checkGrpcDeadlineAndCancellation(e.getMessage(), e);
+            checkGrpcDeadlineAndCancellation(e.getMessage(), e);
 
             throw new UnavailableException("DB is unavailable", e);
         }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbValidator.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbValidator.java
@@ -1,254 +1,43 @@
 package tech.ydb.yoj.repository.ydb.client;
 
-import io.grpc.Context;
-import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import tech.ydb.core.Issue;
 import tech.ydb.core.Status;
-import tech.ydb.core.StatusCode;
-import tech.ydb.yoj.InternalApi;
-import tech.ydb.yoj.repository.db.exception.DeadlineExceededException;
-import tech.ydb.yoj.repository.db.exception.EntityAlreadyExistsException;
-import tech.ydb.yoj.repository.db.exception.GenericSchemaException;
-import tech.ydb.yoj.repository.db.exception.OptimisticLockException;
-import tech.ydb.yoj.repository.db.exception.QueryCancelledException;
-import tech.ydb.yoj.repository.ydb.exception.BadSessionException;
-import tech.ydb.yoj.repository.ydb.exception.YdbClientInternalException;
-import tech.ydb.yoj.repository.ydb.exception.YdbComponentUnavailableException;
-import tech.ydb.yoj.repository.ydb.exception.YdbOverloadedException;
-import tech.ydb.yoj.repository.ydb.exception.YdbPreconditionFailedException;
-import tech.ydb.yoj.repository.ydb.exception.YdbRepositoryException;
-import tech.ydb.yoj.repository.ydb.exception.YdbResultSetTooBigException;
-import tech.ydb.yoj.repository.ydb.exception.YdbUnauthenticatedException;
-import tech.ydb.yoj.repository.ydb.exception.YdbUnauthorizedException;
-import tech.ydb.yoj.util.lang.Strings;
+import tech.ydb.yoj.ExperimentalApi;
+import tech.ydb.yoj.repository.db.exception.RepositoryException;
 
-import javax.annotation.Nullable;
-import java.util.function.Predicate;
+/**
+ * Mapper from YDB {@code Status}es into {@code RepositoryException}s.
+ * <br>Assumed to be stateless (not dependent on YDB transport, YDB session, YOJ transaction-local context,
+ * GRPC context or whatever.)
+ *
+ * <p><strong>WARNING: This is an Experimental low-level API.</strong> Please use as advised by YOJ developers.
+ * This API might change at any time or disappear entirely <strong>without any prior notice!</strong>
+ */
+@ExperimentalApi(issue = "https://github.com/ydb-platform/yoj-project/issues/165")
+public interface YdbValidator {
+    YdbValidator DEFAULT = YdbValidatorImpl.INSTANCE;
 
-import static lombok.AccessLevel.PRIVATE;
+    /**
+     * Validates that {@code status} is successful, and throws an appropriate subtype of {@link RepositoryException}
+     * if {@code status} is an error.
+     *
+     * @param request  YDB request being made. Not machine-readable in general, but may be checked against known
+     *                 constants in a limited number of cases, <em>e.g.</em>:
+     *                 <ul>
+     *                 <li>{@link tech.ydb.yoj.repository.ydb.client.YdbSessionManager#REQUEST_GET_SESSION acquire session from pool/create new session},</li>
+     *                 <li>{@link tech.ydb.yoj.repository.ydb.YdbRepositoryTransaction#REQUEST_COMMIT commit transaction},</li>
+     *                 <li>{@link tech.ydb.yoj.repository.ydb.YdbRepositoryTransaction#REQUEST_ROLLBACK rollback transaction}</li>
+     *                 </ul>
+     * @param status   YDB status of the response
+     * @param response YDB response string, not machine-readable
+     * @throws RepositoryException error corresponding to the {@code status}
+     */
+    void validate(String request, Status status, String response) throws RepositoryException;
 
-@InternalApi
-public final class YdbValidator {
-    private static final Logger log = LoggerFactory.getLogger(YdbValidator.class);
-
-    private YdbValidator() {
-    }
-
-    public static void validate(String request, Status status, String response) {
-        StatusCode statusCode = status.getCode();
-        Issue[] issues = status.getIssues();
-
-        switch (statusCode) {
-            // Success. Do nothing ;-)
-            case SUCCESS -> {
-            }
-
-            // Current session can no longer be used. Retry immediately by creating a new session
-            case BAD_SESSION,      // This session is no longer available. Create a new session
-                 SESSION_EXPIRED,  // The session has already expired. Create a new session
-                 NOT_FOUND -> {    // Prepared statement or tx was not found in current session. Create a new session
-                throw new BadSessionException(response);
-            }
-
-            // Transaction locks invalidated. Retry immediately
-            case ABORTED -> throw new OptimisticLockException(response);
-
-            // The query cannot be executed in the current state. Non-retryable in general
-            // - Primary key/UNIQUE index violations: Retry immediately (EntityAlreadyExistsException)
-            // - Attempt to return a result set larger than ~50M: Non-retryable (YdbResultSetTooBigException)
-            // - Other "failed preconditions" unknown to YOJ: Non-retryable (YdbPreconditionFailedException)
-            case PRECONDITION_FAILED -> {
-                if (is(issues, IssueCode.CONSTRAINT_VIOLATION::matches)) {
-                    throw new EntityAlreadyExistsException("Entity already exists" + errorMessageFrom(issues));
-                } else if (is(issues, IssueCode.QUERY_RESULT_SIZE_EXCEEDED::matches)) {
-                    throw new YdbResultSetTooBigException(request, response);
-                } else {
-                    throw new YdbPreconditionFailedException(request, response);
-                }
-            }
-
-            // DB overloaded and similar conditions. Slow retry with exponential backoff
-            case OVERLOADED,
-                 // DB took too long to respond
-                 TIMEOUT,
-                 // The request was cancelled because the request timeout (CancelAfter) has expired. The request has been cancelled on the server
-                 CANCELLED,
-                 // Not enough resources to process the request
-                 CLIENT_RESOURCE_EXHAUSTED,
-                 // Deadline expired before the request was sent to the server
-                 CLIENT_DEADLINE_EXPIRED,
-                 // The request was cancelled on the client, at the transport level (because the GRPC deadline expired)
-                 CLIENT_DEADLINE_EXCEEDED -> {
-                checkGrpcDeadlineAndCancellation(response, null);
-
-                // The result of the request is unknown; it might have been cancelled... or it executed successfully!
-                log.warn("""
-                        Database is overloaded, but we still got a reply from the DB
-                        Request: {}
-                        Response: {}""", request, response);
-                throw new YdbOverloadedException(request, response);
-            }
-
-            // Unknown error on the client side (most often at the transport level). Fast retry with fixed interval
-            case CLIENT_CANCELLED,
-                 CLIENT_GRPC_ERROR,
-                 CLIENT_INTERNAL_ERROR -> {
-                checkGrpcDeadlineAndCancellation(response, null);
-
-                log.warn("""
-                        YDB SDK internal error or cancellation
-                        Request: {}
-                        Response: {}""", request, response);
-                throw new YdbClientInternalException(request, response);
-            }
-
-            // DB, one of its components, or the transport is temporarily unavailable. Fast retry with fixed interval
-            case UNAVAILABLE,               // DB responded that it or some of its subsystems are unavailable
-                 TRANSPORT_UNAVAILABLE,     // Network connectivity issues
-                 CLIENT_DISCOVERY_FAILED,   // Error occurred while retrieving the list of endpoints
-                 CLIENT_LIMITS_REACHED,     // Client-side session limit reached
-                 SESSION_BUSY,              // Another query is being executed in this session, retry with a new session
-                 UNDETERMINED -> {
-                // FIXME(nvamelichev): SESSION_BUSY is here only because it needs a retry with some delay, not immediate
-                // We should handle SESSION_BUSY separately, e.g. by adding a RetryPolicy arg to BadSessionException
-                // (see https://ydb.tech/docs/en/reference/ydb-sdk/ydb-status-codes?version=v25.2)
-
-                checkGrpcDeadlineAndCancellation(response, null);
-
-                log.warn("""
-                        Some database components are not available, but we still got a reply from the DB
-                        Request: {}
-                        Response: {}""", request, response);
-                throw new YdbComponentUnavailableException(request, response);
-            }
-
-            // GRPC client reports that the request was not authenticated properly. Retry immediately
-            // This is an internal error, but there may have been an issue with issuing the token, so we retry.
-            // If that doesn’t work, we will propagate the error quickly enough.
-            case CLIENT_UNAUTHENTICATED -> {
-                log.warn("""
-                        Unauthenticated request to the database
-                        Request: {}
-                        Response: {}""", request, response);
-                throw new YdbUnauthenticatedException(request, response);
-            }
-
-            // DB reports that the request is unauthorized. Retry immediately
-            // Retries might help in case e.g. access permissions are updated in an eventually-consistent way
-            case UNAUTHORIZED -> {
-                log.warn("""
-                        Unauthorized request to the database
-                        Request: {}
-                        Response: {}""", request, response);
-                throw new YdbUnauthorizedException(request, response);
-            }
-
-            // Database schema problem, e.g. trying to access a non-existent table, column etc. No retries
-            case SCHEME_ERROR -> throw new GenericSchemaException(Strings.join("\n", "Schema error", request, response));
-
-            // Serious internal error. No retries
-            case CLIENT_CALL_UNIMPLEMENTED,
-                 BAD_REQUEST,
-                 UNSUPPORTED,
-                 INTERNAL_ERROR,
-                 GENERIC_ERROR,
-                 UNUSED_STATUS,
-                 ALREADY_EXISTS -> { // Not used by {Table,Query}Service. We consider it fatal
-                log.error("""
-                        Bad response status
-                        Request: {}
-                        Response: {}""", request, response);
-                throw new YdbRepositoryException(request, response);
-            }
-
-            // Unknown YDB status code. No retries
-            default -> {
-                log.error("""
-                        Unknown YDB status code, treating as non-retryable
-                        Request: {}
-                        Response: {}""", request, response);
-                throw new YdbRepositoryException(request, response);
-            }
-        }
-    }
-
-    public static boolean isTransactionClosedByServer(Status status) {
-        return switch (status.getCode()) {
-            case UNUSED_STATUS,
-                 ALREADY_EXISTS,
-                 BAD_REQUEST,
-                 UNAUTHORIZED,
-                 INTERNAL_ERROR,
-                 ABORTED,
-                 UNAVAILABLE,
-                 OVERLOADED,
-                 SCHEME_ERROR,
-                 GENERIC_ERROR,
-                 TIMEOUT,
-                 BAD_SESSION,
-                 PRECONDITION_FAILED,
-                 NOT_FOUND,
-                 SESSION_EXPIRED,
-                 CANCELLED,
-                 UNDETERMINED,
-                 UNSUPPORTED,
-                 SESSION_BUSY,
-                 EXTERNAL_ERROR -> true;
-            case SUCCESS,
-                 TRANSPORT_UNAVAILABLE,
-                 CLIENT_CANCELLED,
-                 CLIENT_CALL_UNIMPLEMENTED,
-                 CLIENT_DEADLINE_EXCEEDED,
-                 CLIENT_INTERNAL_ERROR,
-                 CLIENT_UNAUTHENTICATED,
-                 CLIENT_DEADLINE_EXPIRED,
-                 CLIENT_DISCOVERY_FAILED,
-                 CLIENT_LIMITS_REACHED,
-                 CLIENT_RESOURCE_EXHAUSTED,
-                 CLIENT_GRPC_ERROR -> false;
-        };
-    }
-
-    public static void checkGrpcDeadlineAndCancellation(String errorMessage, @Nullable Throwable cause) {
-        if (Context.current().getDeadline() != null && Context.current().getDeadline().isExpired()) {
-            // GRPC deadline for the current GRPC context has expired. We need to throw a separate exception to avoid retries
-            throw new DeadlineExceededException("DB query deadline exceeded. Response from DB: " + errorMessage, cause);
-        } else if (Context.current().isCancelled()) {
-            // Client has cancelled the GRPC request. Throw a separate exception to avoid retries
-            throw new QueryCancelledException("DB query cancelled. Response from DB: " + errorMessage);
-        }
-    }
-
-    private static boolean is(Issue[] issues, Predicate<Issue> predicate) {
-        for (Issue issue : issues) {
-            if (predicate.test(issue) || (issue.getIssues().length > 0 && is(issue.getIssues(), predicate))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static String errorMessageFrom(Issue[] issues) {
-        StringBuilder sb = new StringBuilder();
-        for (Issue issue : issues) {
-            sb.append(": ");
-            sb.append(issue.getMessage());
-        }
-        return sb.toString();
-    }
-
-    @RequiredArgsConstructor(access = PRIVATE)
-    private enum IssueCode {
-        CONSTRAINT_VIOLATION(2012),
-        QUERY_RESULT_SIZE_EXCEEDED(2013)
-        ;
-
-        private final int issueCode;
-
-        public boolean matches(Issue msg) {
-            return msg.getCode() == issueCode;
-        }
-    }
+    /**
+     * Checks if an error {@code status} resulted in a termination of YDB transaction.
+     *
+     * @param status YDB status
+     * @return {@code true} if YDB transaction is no longer valid after receiving this {@code status}; {@code false} otherwise
+     */
+    boolean isTransactionClosedByServer(Status status);
 }

--- a/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbValidatorImpl.java
+++ b/repository-ydb-v2/src/main/java/tech/ydb/yoj/repository/ydb/client/YdbValidatorImpl.java
@@ -1,0 +1,246 @@
+package tech.ydb.yoj.repository.ydb.client;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tech.ydb.core.Issue;
+import tech.ydb.core.Status;
+import tech.ydb.core.StatusCode;
+import tech.ydb.yoj.InternalApi;
+import tech.ydb.yoj.repository.db.exception.EntityAlreadyExistsException;
+import tech.ydb.yoj.repository.db.exception.GenericSchemaException;
+import tech.ydb.yoj.repository.db.exception.OptimisticLockException;
+import tech.ydb.yoj.repository.db.exception.RepositoryException;
+import tech.ydb.yoj.repository.ydb.exception.BadSessionException;
+import tech.ydb.yoj.repository.ydb.exception.YdbClientInternalException;
+import tech.ydb.yoj.repository.ydb.exception.YdbComponentUnavailableException;
+import tech.ydb.yoj.repository.ydb.exception.YdbOverloadedException;
+import tech.ydb.yoj.repository.ydb.exception.YdbPreconditionFailedException;
+import tech.ydb.yoj.repository.ydb.exception.YdbRepositoryException;
+import tech.ydb.yoj.repository.ydb.exception.YdbResultSetTooBigException;
+import tech.ydb.yoj.repository.ydb.exception.YdbUnauthenticatedException;
+import tech.ydb.yoj.repository.ydb.exception.YdbUnauthorizedException;
+import tech.ydb.yoj.util.lang.Strings;
+
+import java.util.function.Predicate;
+
+import static lombok.AccessLevel.PRIVATE;
+import static tech.ydb.yoj.repository.ydb.YdbOperations.checkGrpcDeadlineAndCancellation;
+
+@InternalApi
+public final class YdbValidatorImpl implements YdbValidator {
+    private static final Logger log = LoggerFactory.getLogger(YdbValidator.class);
+
+    public static final YdbValidator INSTANCE = new YdbValidatorImpl();
+
+    private YdbValidatorImpl() {
+    }
+
+    @Override
+    public void validate(String request, Status status, String response) throws RepositoryException {
+        StatusCode statusCode = status.getCode();
+        Issue[] issues = status.getIssues();
+
+        switch (statusCode) {
+            // Success. Do nothing ;-)
+            case SUCCESS -> {
+            }
+
+            // Current session can no longer be used. Retry immediately by creating a new session
+            case BAD_SESSION,      // This session is no longer available. Create a new session
+                 SESSION_EXPIRED,  // The session has already expired. Create a new session
+                 NOT_FOUND -> {    // Prepared statement or tx was not found in current session. Create a new session
+                throw new BadSessionException(response);
+            }
+
+            // Transaction locks invalidated. Retry immediately
+            case ABORTED -> throw new OptimisticLockException(response);
+
+            // The query cannot be executed in the current state. Non-retryable in general
+            // - Primary key/UNIQUE index violations: Retry immediately (EntityAlreadyExistsException)
+            // - Attempt to return a result set larger than ~50M: Non-retryable (YdbResultSetTooBigException)
+            // - Other "failed preconditions" unknown to YOJ: Non-retryable (YdbPreconditionFailedException)
+            case PRECONDITION_FAILED -> {
+                if (YdbValidatorImpl.is(issues, YdbValidatorImpl.IssueCode.CONSTRAINT_VIOLATION::matches)) {
+                    throw new EntityAlreadyExistsException("Entity already exists" + YdbValidatorImpl.errorMessageFrom(issues));
+                } else if (YdbValidatorImpl.is(issues, YdbValidatorImpl.IssueCode.QUERY_RESULT_SIZE_EXCEEDED::matches)) {
+                    throw new YdbResultSetTooBigException(request, response);
+                } else {
+                    throw new YdbPreconditionFailedException(request, response);
+                }
+            }
+
+            // DB overloaded and similar conditions. Slow retry with exponential backoff
+            case OVERLOADED,
+                 // DB took too long to respond
+                 TIMEOUT,
+                 // The request was cancelled because the request timeout (CancelAfter) has expired. The request has been cancelled on the server
+                 CANCELLED,
+                 // Not enough resources to process the request
+                 CLIENT_RESOURCE_EXHAUSTED,
+                 // Deadline expired before the request was sent to the server
+                 CLIENT_DEADLINE_EXPIRED,
+                 // The request was cancelled on the client, at the transport level (because the GRPC deadline expired)
+                 CLIENT_DEADLINE_EXCEEDED -> {
+                checkGrpcDeadlineAndCancellation(response, null);
+
+                // The result of the request is unknown; it might have been cancelled... or it executed successfully!
+                log.warn("""
+                        Database is overloaded, but we still got a reply from the DB
+                        Request: {}
+                        Response: {}""", request, response);
+                throw new YdbOverloadedException(request, response);
+            }
+
+            // Unknown error on the client side (most often at the transport level). Fast retry with fixed interval
+            case CLIENT_CANCELLED,
+                 CLIENT_GRPC_ERROR,
+                 CLIENT_INTERNAL_ERROR -> {
+                checkGrpcDeadlineAndCancellation(response, null);
+
+                log.warn("""
+                        YDB SDK internal error or cancellation
+                        Request: {}
+                        Response: {}""", request, response);
+                throw new YdbClientInternalException(request, response);
+            }
+
+            // DB, one of its components, or the transport is temporarily unavailable. Fast retry with fixed interval
+            case UNAVAILABLE,               // DB responded that it or some of its subsystems are unavailable
+                 TRANSPORT_UNAVAILABLE,     // Network connectivity issues
+                 CLIENT_DISCOVERY_FAILED,   // Error occurred while retrieving the list of endpoints
+                 CLIENT_LIMITS_REACHED,     // Client-side session limit reached
+                 SESSION_BUSY,              // Another query is being executed in this session, retry with a new session
+                 UNDETERMINED -> {
+                // FIXME(nvamelichev): SESSION_BUSY is here only because it needs a retry with some delay, not immediate
+                // We should handle SESSION_BUSY separately, e.g. by adding a RetryPolicy arg to BadSessionException
+                // (see https://ydb.tech/docs/en/reference/ydb-sdk/ydb-status-codes?version=v25.2)
+
+                checkGrpcDeadlineAndCancellation(response, null);
+
+                log.warn("""
+                        Some database components are not available, but we still got a reply from the DB
+                        Request: {}
+                        Response: {}""", request, response);
+                throw new YdbComponentUnavailableException(request, response);
+            }
+
+            // GRPC client reports that the request was not authenticated properly. Retry immediately
+            // This is an internal error, but there may have been an issue with issuing the token, so we retry.
+            // If that doesn’t work, we will propagate the error quickly enough.
+            case CLIENT_UNAUTHENTICATED -> {
+                log.warn("""
+                        Unauthenticated request to the database
+                        Request: {}
+                        Response: {}""", request, response);
+                throw new YdbUnauthenticatedException(request, response);
+            }
+
+            // DB reports that the request is unauthorized. Retry immediately
+            // Retries might help in case e.g. access permissions are updated in an eventually-consistent way
+            case UNAUTHORIZED -> {
+                log.warn("""
+                        Unauthorized request to the database
+                        Request: {}
+                        Response: {}""", request, response);
+                throw new YdbUnauthorizedException(request, response);
+            }
+
+            // Database schema problem, e.g. trying to access a non-existent table, column etc. No retries
+            case SCHEME_ERROR ->
+                    throw new GenericSchemaException(Strings.join("\n", "Schema error", request, response));
+
+            // Serious internal error. No retries
+            case CLIENT_CALL_UNIMPLEMENTED,
+                 BAD_REQUEST,
+                 UNSUPPORTED,
+                 INTERNAL_ERROR,
+                 GENERIC_ERROR,
+                 UNUSED_STATUS,
+                 ALREADY_EXISTS -> { // Not used by {Table,Query}Service. We consider it fatal
+                log.error("""
+                        Bad response status
+                        Request: {}
+                        Response: {}""", request, response);
+                throw new YdbRepositoryException(request, response);
+            }
+
+            // Unknown YDB status code. No retries
+            default -> {
+                log.error("""
+                        Unknown YDB status code, treating as non-retryable
+                        Request: {}
+                        Response: {}""", request, response);
+                throw new YdbRepositoryException(request, response);
+            }
+        }
+    }
+
+    @Override
+    public boolean isTransactionClosedByServer(Status status) {
+        return switch (status.getCode()) {
+            case UNUSED_STATUS,
+                 ALREADY_EXISTS,
+                 BAD_REQUEST,
+                 UNAUTHORIZED,
+                 INTERNAL_ERROR,
+                 ABORTED,
+                 UNAVAILABLE,
+                 OVERLOADED,
+                 SCHEME_ERROR,
+                 GENERIC_ERROR,
+                 TIMEOUT,
+                 BAD_SESSION,
+                 PRECONDITION_FAILED,
+                 NOT_FOUND,
+                 SESSION_EXPIRED,
+                 CANCELLED,
+                 UNDETERMINED,
+                 UNSUPPORTED,
+                 SESSION_BUSY,
+                 EXTERNAL_ERROR -> true;
+            case SUCCESS,
+                 TRANSPORT_UNAVAILABLE,
+                 CLIENT_CANCELLED,
+                 CLIENT_CALL_UNIMPLEMENTED,
+                 CLIENT_DEADLINE_EXCEEDED,
+                 CLIENT_INTERNAL_ERROR,
+                 CLIENT_UNAUTHENTICATED,
+                 CLIENT_DEADLINE_EXPIRED,
+                 CLIENT_DISCOVERY_FAILED,
+                 CLIENT_LIMITS_REACHED,
+                 CLIENT_RESOURCE_EXHAUSTED,
+                 CLIENT_GRPC_ERROR -> false;
+        };
+    }
+
+    private static boolean is(Issue[] issues, Predicate<Issue> predicate) {
+        for (Issue issue : issues) {
+            if (predicate.test(issue) || (issue.getIssues().length > 0 && is(issue.getIssues(), predicate))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String errorMessageFrom(Issue[] issues) {
+        StringBuilder sb = new StringBuilder();
+        for (Issue issue : issues) {
+            sb.append(": ");
+            sb.append(issue.getMessage());
+        }
+        return sb.toString();
+    }
+
+    @RequiredArgsConstructor(access = PRIVATE)
+    private enum IssueCode {
+        CONSTRAINT_VIOLATION(2012),
+        QUERY_RESULT_SIZE_EXCEEDED(2013);
+
+        private final int issueCode;
+
+        public boolean matches(Issue msg) {
+            return msg.getCode() == issueCode;
+        }
+    }
+}

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryCacheTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryCacheTest.java
@@ -24,6 +24,7 @@ import tech.ydb.yoj.repository.test.sample.model.Complex.Id;
 import tech.ydb.yoj.repository.ydb.client.SessionManager;
 import tech.ydb.yoj.repository.ydb.client.YdbConverter;
 import tech.ydb.yoj.repository.ydb.client.YdbSchemaOperations;
+import tech.ydb.yoj.repository.ydb.client.YdbValidator;
 import tech.ydb.yoj.repository.ydb.statement.FindYqlStatement;
 import tech.ydb.yoj.repository.ydb.statement.MultipleVarsYqlStatement;
 import tech.ydb.yoj.repository.ydb.statement.UpsertYqlStatement;
@@ -59,6 +60,7 @@ public class YdbRepositoryCacheTest {
 
         when(testYdbRepository.getSessionManager()).thenReturn(sessionManager);
         when(testYdbRepository.getSchemaOperations()).thenReturn(schemaOperations);
+        when(testYdbRepository.getYdbValidator()).thenReturn(YdbValidator.DEFAULT);
         when(sessionManager.getSession()).thenReturn(session);
     }
 

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbRepositoryIntegrationTest.java
@@ -21,8 +21,10 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Test;
+import tech.ydb.auth.NopAuthProvider;
 import tech.ydb.common.transaction.TxMode;
 import tech.ydb.common.transaction.YdbTransaction;
+import tech.ydb.core.Status;
 import tech.ydb.core.grpc.YdbHeaders;
 import tech.ydb.core.utils.Version;
 import tech.ydb.proto.OperationProtos;
@@ -62,6 +64,7 @@ import tech.ydb.yoj.repository.db.TableDescriptor;
 import tech.ydb.yoj.repository.db.Tx;
 import tech.ydb.yoj.repository.db.common.CommonConverters;
 import tech.ydb.yoj.repository.db.exception.ConversionException;
+import tech.ydb.yoj.repository.db.exception.RepositoryException;
 import tech.ydb.yoj.repository.db.exception.RetryableException;
 import tech.ydb.yoj.repository.db.exception.UnavailableException;
 import tech.ydb.yoj.repository.db.list.ListRequest;
@@ -84,8 +87,10 @@ import tech.ydb.yoj.repository.test.sample.model.TypeFreak;
 import tech.ydb.yoj.repository.test.sample.model.UniqueProject;
 import tech.ydb.yoj.repository.test.sample.model.WithUnflattenableField;
 import tech.ydb.yoj.repository.ydb.client.SessionManager;
+import tech.ydb.yoj.repository.ydb.client.YdbValidator;
 import tech.ydb.yoj.repository.ydb.compatibility.YdbSchemaCompatibilityChecker;
 import tech.ydb.yoj.repository.ydb.exception.ResultTruncatedException;
+import tech.ydb.yoj.repository.ydb.exception.YdbComponentUnavailableException;
 import tech.ydb.yoj.repository.ydb.exception.YdbOverloadedException;
 import tech.ydb.yoj.repository.ydb.exception.YdbRepositoryException;
 import tech.ydb.yoj.repository.ydb.exception.YdbResultSetTooBigException;
@@ -109,6 +114,7 @@ import tech.ydb.yoj.repository.ydb.yql.YqlPredicate;
 import tech.ydb.yoj.repository.ydb.yql.YqlPrimitiveType;
 import tech.ydb.yoj.repository.ydb.yql.YqlStatementPart;
 import tech.ydb.yoj.repository.ydb.yql.YqlView;
+import tech.ydb.yoj.util.retry.RetryPolicy;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
@@ -130,8 +136,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static tech.ydb.proto.StatusCodesProtos.StatusIds.StatusCode.UNDETERMINED;
 import static tech.ydb.yoj.repository.db.EntityExpressions.newFilterBuilder;
 import static tech.ydb.yoj.repository.db.EntityExpressions.newOrderBuilder;
+import static tech.ydb.yoj.repository.ydb.YdbRepositoryTransaction.REQUEST_COMMIT;
 
 public class YdbRepositoryIntegrationTest extends RepositoryTest {
     private final IndexedEntity e1 =
@@ -171,7 +179,7 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
 
         var hostAndPort = config.getHostAndPort();
         NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(hostAndPort.getHost(), hostAndPort.getPort())
-                .maxInboundMessageSize(50000000)
+                .maxInboundMessageSize(50_000_000)
                 .intercept(MetadataUtils.newAttachHeadersInterceptor(proxyHeaders));
         ManagedChannel channel;
         if (config.isUseTLS()) {
@@ -1466,6 +1474,52 @@ public class YdbRepositoryIntegrationTest extends RepositoryTest {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    @Test
+    public void customYdbValidator() {
+        class MyCustomRetryableException extends RetryableException {
+            MyCustomRetryableException(String message, RetryPolicy retryPolicy, Throwable cause) {
+                super(message, retryPolicy, cause);
+            }
+        }
+
+        var validator = new YdbValidator() {
+            @Override
+            public void validate(String request, Status status, String response) throws RepositoryException {
+                if (REQUEST_COMMIT.equals(request)) {
+                    try {
+                        DEFAULT.validate(request, status, response);
+                    } catch (YdbComponentUnavailableException | YdbOverloadedException e) {
+                        // You can also check Tx.Current.get().getName() here, to enable the functionality
+                        // only in select transactions
+                        throw new MyCustomRetryableException(e.getMessage(), e.getRetryPolicy(), e.getCause());
+                    }
+                }
+            }
+
+            @Override
+            public boolean isTransactionClosedByServer(Status status) {
+                return DEFAULT.isTransactionClosedByServer(status);
+            }
+        };
+
+        var proxiedRepository = new YdbRepository(
+                getProxyServerConfig(),
+                TestYdbRepository.createRepositorySettings().withYdbValidator(validator),
+                NopAuthProvider.INSTANCE,
+                List.of()
+        );
+        try {
+            var tx = proxiedRepository.startTransaction();
+            tx.table(Project.class).findAll();
+            runWithModifiedStatusCode(
+                    UNDETERMINED,
+                    () -> assertThatThrownBy(tx::commit).isInstanceOf(MyCustomRetryableException.class)
+            );
+        } finally {
+            proxiedRepository.shutdown();
         }
     }
 

--- a/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbSpliteratorTest.java
+++ b/repository-ydb-v2/src/test/java/tech/ydb/yoj/repository/ydb/YdbSpliteratorTest.java
@@ -8,6 +8,7 @@ import tech.ydb.core.Status;
 import tech.ydb.core.StatusCode;
 import tech.ydb.yoj.repository.db.exception.DeadlineExceededException;
 import tech.ydb.yoj.repository.db.exception.QueryInterruptedException;
+import tech.ydb.yoj.repository.ydb.client.YdbValidator;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -73,7 +74,8 @@ public class YdbSpliteratorTest {
     @Test
     @SneakyThrows
     public void endStreamWhenSupplerOfferValue() {
-        YdbSpliterator<Integer> spliterator = new YdbSpliterator<>("stream", false, Duration.ofMillis(500));
+        Duration timeout = Duration.ofMillis(500);
+        YdbSpliterator<Integer> spliterator = new YdbSpliterator<>("stream", YdbValidator.DEFAULT, false, timeout);
 
         spliterator.onNext(1);
 
@@ -198,7 +200,7 @@ public class YdbSpliteratorTest {
         }
 
         public static ReadTableMock start(Duration timeout) {
-            YdbSpliterator<Integer> spliterator = new YdbSpliterator<>("stream", false, timeout);
+            YdbSpliterator<Integer> spliterator = new YdbSpliterator<>("stream", YdbValidator.DEFAULT, false, timeout);
 
             ReadTableMock mock = new ReadTableMock(spliterator);
             mock.run();


### PR DESCRIPTION
This opens the door for error handling customization that can work **without** changing the core error handling logic in `repository-ydb-v2`.